### PR TITLE
Unit Converter Phase 3 PR 

### DIFF
--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -3,17 +3,18 @@ import CopyButton from "./CopyButton";
 
 function CodeBlock({ title, code }) {
   // Function to provide the code text to the CopyButton
-
-  const handleCopy = () => code;
+  const getCode = () => code.toString();
 
   return (
-    <div className="mb-4 relative">
+    <div className="mb-4 relative group">
       <div className="mb-2 text-sm font-bold text-gray-400">{title}</div>
-      <div className="absolute top-0 right-0 mb-2">
-        <CopyButton onCopy={handleCopy} />
-      </div>
       <div className="p-3 bg-gray-200 rounded relative">
-        <code>{code}</code>
+        <pre>
+          <code>{code}</code>
+        </pre>
+      </div>
+      <div className="absolute top-0 right-0 mb-2 hidden group-hover:flex">
+        <CopyButton onCopy={getCode} />
       </div>
     </div>
   );

--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -1,12 +1,12 @@
 import React from "react";
 import CopyButton from "./CopyButton";
 
-function CodeBlock({ title, code, unit }) {
+function CodeBlock({ title, code }) {
   return (
     <div className="mb-4">
       <div className="mb-2 text-sm font-bold text-gray-400">{title}</div>
       <div className="p-3 bg-gray-200 rounded">
-        <code>{`${code}: ${unit};`}</code>
+        <code>{code}</code>
       </div>
     </div>
   );

--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -2,10 +2,17 @@ import React from "react";
 import CopyButton from "./CopyButton";
 
 function CodeBlock({ title, code }) {
+  // Function to provide the code text to the CopyButton
+
+  const handleCopy = () => code;
+
   return (
-    <div className="mb-4">
+    <div className="mb-4 relative">
       <div className="mb-2 text-sm font-bold text-gray-400">{title}</div>
-      <div className="p-3 bg-gray-200 rounded">
+      <div className="absolute top-0 right-0 mb-2">
+        <CopyButton onCopy={handleCopy} />
+      </div>
+      <div className="p-3 bg-gray-200 rounded relative">
         <code>{code}</code>
       </div>
     </div>

--- a/fetools-app/src/components/TabSwitcher.jsx
+++ b/fetools-app/src/components/TabSwitcher.jsx
@@ -1,70 +1,73 @@
-import { useState } from "react"
+import { useState } from "react";
 import {
-    Accordion,
-    AccordionContent,
-    AccordionItem,
-    AccordionTrigger,
-} from "@/components/ui/accordion"
-  
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
-export default function TabSwitcher({buttons, children}){
+export default function TabSwitcher({ buttons, children, title }) {
+  const [selectedButton, setSelectedButton] = useState(buttons[0]);
+  const [displayedContent, setDisplayedContent] = useState(0);
 
-    const [ selectedButton, setSelectedButton] = useState(buttons[0])
-    const [ displayedContent, setDisplayedContent] = useState(0)
+  const radioButtons = (array) =>
+    array.map((btn, idx) => (
+      <label
+        key={`radioBtn-${idx}`}
+        id={btn}
+        name="tab-switcher-buttons"
+        className="font-bold text-sm leading-none"
+      >
+        <input
+          type="radio"
+          value={btn}
+          checked={selectedButton === btn}
+          onChange={(evt) => (
+            handleOptionChange(evt), setDisplayedContent(idx)
+          )}
+          className="inline-block align-middle mr-1"
+        />
+        <p className="inline-block leading-none">{btn}</p>
+      </label>
+    ));
 
-    const radioButtons = array => array.map((btn, idx)=>(
-            <label key={`radioBtn-${idx}`} id={btn} name="tab-switcher-buttons" 
-            className="font-bold text-sm leading-none">
-                <input type="radio" value={btn} 
-                checked={selectedButton===btn} 
-                onChange={ evt => (
-                    handleOptionChange(evt),
-                    setDisplayedContent(idx))
-                } className="inline-block align-middle mr-1"/>
-                <p className="inline-block leading-none">{btn}</p>
-            </label>
-        )
-    )
-
-    return(
-        <div id="tab-switcher" 
-        className="flex flex-col flex-1 p-6 mb-2
-        sm:p-12 lg:px-48 lg:py-20">
-            <div id="tab-switcher-sm" className="max-[420px]:hidden">
-                <div className="flex flex-1 justify-between ">
-                    <h2 className="font-bold text-3xl leading-none">Tab Switcher</h2>
-                    <fieldset className="flex flex-wrap items-center gap-x-8">
-                        {radioButtons(buttons)}
-                    </fieldset>
-                </div>
-
-                <div className="flex-1 flex-col">
-                    {children[displayedContent]}
-                </div>
-            </div>
-
-            <div id="tab-switcher-mobile" className="min-[420px]:hidden">
-                <Accordion type="single" collapsible>
-                    <AccordionItem value="item-1">
-                        <AccordionTrigger 
-                        className="font-bold text-3xl leading-none">Tab Switcher</AccordionTrigger>
-                        <AccordionContent>
-                            <fieldset className="flex flex-wrap items-center gap-x-8">
-                                {radioButtons(buttons)}
-                            </fieldset>
-                        </AccordionContent>
-                    </AccordionItem>
-                </Accordion>
-
-                <div className="flex-1 flex-col mt-3">
-                    {children[displayedContent]}
-                </div>
-            </div>
-
+  return (
+    <div
+      id="tab-switcher"
+      className="flex flex-col flex-1  
+          sm:p-8 lg:px-48 lg:pt-10"
+    >
+      <div id="tab-switcher-sm" className="max-[420px]:hidden">
+        <div className="flex flex-1 justify-between ">
+          <h2 className="font-bold text-3xl leading-none mb-3">{title}</h2>
+          <fieldset className="flex flex-wrap items-center gap-x-8 mb-3">
+            {radioButtons(buttons)}
+          </fieldset>
         </div>
-    )
 
-    function handleOptionChange(evt){
-        setSelectedButton(evt.target.value)
-    }
+        <div className="flex-1 flex-col">{children[displayedContent]}</div>
+      </div>
+
+      <div id="tab-switcher-mobile" className="min-[420px]:hidden">
+        <Accordion type="single" collapsible>
+          <AccordionItem value="item-1">
+            <AccordionTrigger className="font-bold text-3xl leading-none">
+              Tab Switcher
+            </AccordionTrigger>
+            <AccordionContent>
+              <fieldset className="flex flex-wrap items-center gap-x-8">
+                {radioButtons(buttons)}
+              </fieldset>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+
+        <div className="flex-1 flex-col mt-3">{children[displayedContent]}</div>
+      </div>
+    </div>
+  );
+
+  function handleOptionChange(evt) {
+    setSelectedButton(evt.target.value);
+  }
 }

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -1,7 +1,13 @@
 import React, { useRef } from "react";
 import CopyButton from "./CopyButton";
 
-function TextField({ title, value, unit, onValueChange }) {
+function TextField({
+  title,
+  value,
+  unit,
+  onValueChange,
+  inputType = "number",
+}) {
   // A ref to the input element
   const inputRef = useRef(null);
 
@@ -25,7 +31,7 @@ function TextField({ title, value, unit, onValueChange }) {
       <div className="flex border rounded relative">
         <input
           ref={inputRef}
-          type="number"
+          type={inputType}
           className="border rounded border-black w-28 py-2 px-3 text-gray-400 leading-tight focus:outline-none focus:shadow-outline"
           value={value}
           onChange={onValueChange}

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -2,7 +2,8 @@ import React, { useRef } from "react";
 import CopyButton from "./CopyButton";
 
 function TextField({ title, value, unit, onValueChange }) {
-  const inputRef = useRef(null); // Create a ref to the input element
+  // A ref to the input element
+  const inputRef = useRef(null);
 
   // Function to concatenate value and unit, used for the copy function
   const getValueWithUnit = () => {

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -1,10 +1,19 @@
-import React from "react";
+import React, { useRef } from "react";
 import CopyButton from "./CopyButton";
 
 function TextField({ title, value, unit, onValueChange }) {
+  const inputRef = useRef(null); // Create a ref to the input element
+
   // Function to concatenate value and unit, used for the copy function
   const getValueWithUnit = () => {
     return unit ? `${value} ${unit}` : value.toString();
+  };
+
+  // Function to handle click inside the input field
+  const handleInputClick = () => {
+    if (inputRef.current) {
+      inputRef.current.select(); // Select all text in the input field
+    }
   };
 
   return (
@@ -14,10 +23,12 @@ function TextField({ title, value, unit, onValueChange }) {
       </label>
       <div className="flex border rounded relative">
         <input
+          ref={inputRef}
           type="number"
           className="border rounded border-black w-28 py-2 px-3 text-gray-400 leading-tight focus:outline-none focus:shadow-outline"
           value={value}
           onChange={onValueChange}
+          onFocus={handleInputClick}
         />
         {unit && (
           <span className="px-2 text-gray-700 absolute inset-y-0 right-0 flex items-center mr-2 pointer-events-none font-semibold">

--- a/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
+++ b/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
@@ -1,23 +1,25 @@
-export default function GoDeeper({linksData}){
+export default function GoDeeper({ linksData }) {
+  const anchorElements = (array) =>
+    array.map(({ url, textValue }, idx) => (
+      <li key={`GoLink-${idx}`}>
+        <a
+          href={url}
+          className="underline underline-offset-4 text-md font-bold"
+        >
+          {textValue}
+        </a>
+      </li>
+    ));
 
-    const anchorElements = array => array.map(({url, textValue}, idx)=> (
-          <li key={`GoLink-${idx}`}>
-              <a 
-                href={url}
-                className="underline underline-offset-4 text-md font-bold">
-                  {textValue}
-              </a>
-          </li>
-      ))
-
-    return(
-        <aside className="flex flex-col flex-1 gap-5 p-6
-        sm:p-12 lg:px-48 lg:py-20">
-            <h2 className="font-bold text-3xl leading-none">Go Deeper...</h2>
-            <ul className="flex flex-col gap-3 list-none list-inside">
-               {anchorElements(linksData)} 
-            </ul>
-        </aside>
-    )
-
+  return (
+    <aside
+      className="flex flex-col flex-1 gap-5 
+        sm:p-12 lg:px-48 lg:pt-8 lg:pb-10"
+    >
+      <h2 className="font-bold text-3xl leading-none">Go Deeper...</h2>
+      <ul className="flex flex-col gap-3 list-none list-inside">
+        {anchorElements(linksData)}
+      </ul>
+    </aside>
+  );
 }

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -4,7 +4,7 @@ import CopyButton from "../components/CopyButton";
 import TextField from "../components/TextField";
 import CodeBlock from "../components/CodeBlock";
 
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
 // Function component UnitConverter for converting units between pixels, em/rem, and Tailwind utility classes
 
@@ -62,9 +62,19 @@ function UnitConverter() {
     updateCssSize(newPixels);
   };
 
+  // A ref to the base size input element
+  const baseSizeInputRef = useRef(null);
+
   // Handler for the cog (settings) icon click. Toggles the edit mode state.
   const handleCogClick = () => {
-    setEditMode(!editMode);
+    const newEditMode = !editMode;
+    setEditMode(newEditMode);
+    if (newEditMode) {
+      setTimeout(() => {
+        baseSizeInputRef.current.focus();
+        baseSizeInputRef.current.select();
+      }, 0);
+    }
   };
 
   // Handler for the input field losing focus
@@ -114,6 +124,7 @@ function UnitConverter() {
             {editMode ? (
               <div className="flex border rounded relative">
                 <input
+                  ref={baseSizeInputRef}
                   type="number"
                   className="border rounded border-black w-28 py-2 px-3  text-gray-400 leading-tight"
                   value={basePixelSize}

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -165,28 +165,28 @@ function UnitConverter() {
     <div className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
         ? CodeSamples["NaN"].map((sample) => (
-            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+            <CodeBlock title={sample.title} code={sample.code} />
           ))
         : CodeSamples["px"].map((sample) => (
-            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+            <CodeBlock title={sample.title} code={sample.code} />
           ))}
     </div>,
     <div className="grid grid-cols-4 gap-4">
       {isNaN(em)
         ? CodeSamples["NaN"].map((sample) => (
-            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+            <CodeBlock title={sample.title} code={sample.code} />
           ))
         : CodeSamples["em"].map((sample) => (
-            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+            <CodeBlock title={sample.title} code={sample.code} />
           ))}
     </div>,
     <div className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
         ? CodeSamples["NaN"].map((sample) => (
-            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+            <CodeBlock title={sample.title} code={sample.code} />
           ))
         : CodeSamples["rem"].map((sample) => (
-            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+            <CodeBlock title={sample.title} code={sample.code} />
           ))}
     </div>,
   ];

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -264,14 +264,15 @@ function UnitConverter() {
             className="flex flex-row justify-start items-center border border-black border-dashed p-3 
         min-h-[100px] w-full overflow-auto"
           >
-            <p
-              className="font-arial font-bold text-3xl break-words leading-none"
+            <div
+              contentEditable
+              className="font-arial font-bold text-3xl break-words leading-none focus:outline-none"
               style={{
                 fontSize: cssSize,
               }}
             >
               Lorem ipsum dolor sit amet
-            </p>
+            </div>
           </div>
         </div>
         {/* Section for code blocks */}

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -1,5 +1,7 @@
 import "../index.css";
 import GoDeeper from "../components/ToolsLayout/GoDeeper";
+import ToolHeading from "../components/ToolsLayout/ToolHeading";
+import ToolHeaderSection from "../components/ToolsLayout/ToolHeaderSection";
 import TextField from "../components/TextField";
 import CodeBlock from "../components/CodeBlock";
 import TabSwitcher from "../components/TabSwitcher";
@@ -88,16 +90,16 @@ function UnitConverter() {
   //links for Go Deeper component
   const linksData = [
     {
-      url: "https://en.wikipedia.org/wiki/Gabe_Newell",
-      textValue: "Dummy Link 1",
+      url: "https://www.w3schools.com/cssref/css_units.php",
+      textValue: "Explore CSS units at W3Schools",
     },
     {
-      url: "https://en.wikipedia.org/wiki/SteamOS",
-      textValue: "Dummy Link 2",
+      url: "https://developer.mozilla.org/en-US/docs/Web/CSS",
+      textValue: "Learn more about CSS values and units at MDN",
     },
     {
-      url: "https://en.wikipedia.org/wiki/Half-Life:_Alyx",
-      textValue: "Dummy Link 3",
+      url: "https://www.youtube.com/watch?v=N5wpD9Ov_To&ab_channel=KevinPowell",
+      textValue: "Are you using the right CSS units? With Kevin Powell",
     },
   ];
 
@@ -194,17 +196,15 @@ function UnitConverter() {
   // JSX for rendering the UI components.
   return (
     <>
-      <main
-      //     className="p-6
-      // sm:p-12 lg:px-48 lg:py-20"
-      >
-        {/* Heading and Sub-Heading*/}
-        <p className="font-arial font-bold text-6xl ml-4">Unit Converter</p>
-        <p className="font-arial text-1xl ml-4 mb-2 text-gray-400">
-          Calculate PX, REM/EM, and Tailwind utility classes with ease.
-        </p>
+      <main>
+        <ToolHeaderSection>
+          <ToolHeading
+            title="Unit Converter"
+            tagline="Calculate PX, REM/EM, and Tailwind utility classes with ease."
+          />
+        </ToolHeaderSection>
         {/* Section for Input Boxes*/}
-        <div className="flex gap-10 p-4 ml-52">
+        <div className="flex gap-10 sm:py-8 sm:px-16 lg:px-80">
           <div className="mb-3">
             <label className="block mb-2 text-sm font-bold text-gray-400">
               Base Size
@@ -258,7 +258,7 @@ function UnitConverter() {
           />
         </div>
         {/* Section for Lorem Ipsum Preview*/}
-        <div className="flex flex-col gap-4 items-start p-4">
+        <div className="flex flex-col gap-4 items-start sm:p-8 lg:px-48">
           <p className="font-arial text-4xl">Preview</p>
           <div
             className="flex flex-row justify-start items-center border border-black border-dashed p-3 

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -19,7 +19,8 @@ function UnitConverter() {
 
   // Update CSS size whenever pixels, em, or Tailwind size changes
   const updateCssSize = (newSizeInPixels) => {
-    setCssSize(`${newSizeInPixels}px`); // Update CSS size
+    // Check if newSizeInPixels is a number, if not, set CSS size to "0px"
+    setCssSize(isNaN(newSizeInPixels) ? "0px" : `${newSizeInPixels}px`); // Update CSS size
   };
 
   // Handler for base pixel size changes
@@ -88,18 +89,6 @@ function UnitConverter() {
       url: "https://en.wikipedia.org/wiki/Half-Life:_Alyx",
       textValue: "Dummy Link 3",
     },
-  ];
-
-  //CSS Properties - *still have to add position*
-  const cssProperties = [
-    { title: "Font Size", cssProperty: "font-size" },
-    { title: "Height", cssProperty: "height" },
-    { title: "Width", cssProperty: "width" },
-    { title: "Margin", cssProperty: "margin" },
-    { title: "Padding", cssProperty: "padding" },
-    { title: "Gap", cssProperty: "gap" },
-    { title: "Border Width", cssProperty: "border-width" },
-    { title: "Position", cssProperty: "top" },
   ];
 
   // JSX for rendering the UI components.
@@ -184,14 +173,7 @@ function UnitConverter() {
 
         {/* Section for code blocks */}
         <div className="grid grid-cols-4 gap-4">
-          {cssProperties.map((item, index) => (
-            <CodeBlock
-              key={index}
-              title={item.title}
-              code={item.cssProperty}
-              unit={`${pixels}px`}
-            />
-          ))}
+          <CodeBlock title="Font Size" code={`font-size: ${pixels}px;`} />
         </div>
         {/* <GoDeeper linksData={linksData} /> */}
       </main>

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -40,6 +40,23 @@ function UnitConverter() {
     setCssSize(isNaN(finalSize) ? "0px" : `${finalSize}px`); // Update CSS size
   };
 
+  // Tailwind Size Conversions
+  const tailwindSizes = [
+    0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 20,
+    24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96,
+  ];
+
+  const TailwindCheck = (TailwindSize) => {
+    const nearestTailwindSize = tailwindSizes.find(
+      (size) => size == TailwindSize
+    );
+    if (nearestTailwindSize !== undefined) {
+      return nearestTailwindSize;
+    }
+    // Return rem value if no exact tailwind size is found
+    return `[${(TailwindSize / 4).toFixed(3)}rem]`;
+  };
+
   // Handler for base pixel size changes
   const handleBasePixelSizeChange = (e) => {
     const newBaseSize = parseFloat(e.target.value);
@@ -55,7 +72,7 @@ function UnitConverter() {
     setPixels(newPixels);
     const newEm = newPixels / basePixelSize;
     setEm(newEm);
-    setTailwindSize(newEm * 4);
+    setTailwindSize(TailwindCheck(newEm * 4));
     updateCssSize(newPixels);
   };
 
@@ -65,14 +82,14 @@ function UnitConverter() {
     setEm(newEm);
     const newPixels = newEm * basePixelSize;
     setPixels(newPixels);
-    setTailwindSize(newEm * 4);
+    setTailwindSize(TailwindCheck(newEm * 4));
     updateCssSize(newPixels);
   };
 
   // Handler for Tailwind size changes
   const handleTailwindChange = (e) => {
     const newTailwindSize = parseFloat(e.target.value);
-    setTailwindSize(newTailwindSize);
+    setTailwindSize(TailwindCheck(newTailwindSize));
     const newEm = newTailwindSize / 4;
     setEm(newEm);
     const newPixels = newEm * basePixelSize;
@@ -271,6 +288,7 @@ function UnitConverter() {
             title="Tailwind Size"
             value={tailwindSize}
             onValueChange={handleTailwindChange}
+            inputType={typeof tailwindSize === "string" ? "text" : "number"}
           />
         </div>
         {/* Section for Lorem Ipsum Preview*/}

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -195,8 +195,8 @@ function UnitConverter() {
   return (
     <>
       <main
-        className="p-6
-    sm:p-12 lg:px-48 lg:py-20"
+      //     className="p-6
+      // sm:p-12 lg:px-48 lg:py-20"
       >
         {/* Heading and Sub-Heading*/}
         <p className="font-arial font-bold text-6xl ml-4">Unit Converter</p>
@@ -281,10 +281,11 @@ function UnitConverter() {
           <TabSwitcher
             buttons={tabButtons}
             children={tabContents}
+            title="Code Samples"
           ></TabSwitcher>
         </div>
 
-        {/* <GoDeeper linksData={linksData} /> */}
+        <GoDeeper linksData={linksData} />
       </main>
     </>
   );

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -19,10 +19,25 @@ function UnitConverter() {
   const [editMode, setEditMode] = useState(false);
   const [cssSize, setCssSize] = useState("16px");
 
+  // State variable to track if the alert has been shown
+  const [alertShown, setAlertShown] = useState(false);
+
   // Update CSS size whenever pixels, em, or Tailwind size changes
   const updateCssSize = (newSizeInPixels) => {
+    let finalSize = newSizeInPixels;
+
+    // Check if newSizeInPixels exceeds the maximum allowed size for the preview (1000)
+    if (newSizeInPixels > 1000 && !alertShown) {
+      finalSize = 1000;
+      // Notify the user that the preview is capped (you might want to throttle this or change the UX for a smoother experience)
+      alert(
+        "Preview is limited to 1000px. Conversion will still be accurate above this value."
+      );
+      setAlertShown(true);
+    }
+
     // Check if newSizeInPixels is a number, if not, set CSS size to "0px"
-    setCssSize(isNaN(newSizeInPixels) ? "0px" : `${newSizeInPixels}px`); // Update CSS size
+    setCssSize(isNaN(finalSize) ? "0px" : `${finalSize}px`); // Update CSS size
   };
 
   // Handler for base pixel size changes
@@ -60,7 +75,8 @@ function UnitConverter() {
     setTailwindSize(newTailwindSize);
     const newEm = newTailwindSize / 4;
     setEm(newEm);
-    setPixels(newEm * basePixelSize);
+    const newPixels = newEm * basePixelSize;
+    setPixels(newPixels);
     updateCssSize(newPixels);
   };
 

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -1,8 +1,8 @@
 import "../index.css";
 import GoDeeper from "../components/ToolsLayout/GoDeeper";
-import CopyButton from "../components/CopyButton";
 import TextField from "../components/TextField";
 import CodeBlock from "../components/CodeBlock";
+import TabSwitcher from "../components/TabSwitcher";
 
 import React, { useState, useRef } from "react";
 
@@ -101,6 +101,96 @@ function UnitConverter() {
     },
   ];
 
+  //All Code Samples
+  const CodeSamples = {
+    px: [
+      { title: "Font Size", code: `font-size: ${pixels}px;` },
+      { title: "Height", code: `height: ${pixels}px;` },
+      { title: "Width", code: `width: ${pixels}px;` },
+      { title: "Margin", code: `margin: ${pixels}px;` },
+      { title: "Padding", code: `padding: ${pixels}px;` },
+      { title: "Gap", code: `gap: ${pixels}px;` },
+      { title: "Border Width", code: `border-width: ${pixels}px;` },
+      {
+        title: "Position",
+        code: `top: ${pixels}px;\nright: ${pixels}px;\nbottom: ${pixels}px;\nleft: ${pixels}px;`,
+      },
+    ],
+    rem: [
+      { title: "Font Size", code: `font-size: ${em}rem;` },
+      { title: "Height", code: `height: ${em}rem;` },
+      { title: "Width", code: `width: ${em}rem;` },
+      { title: "Margin", code: `margin: ${em}rem;` },
+      { title: "Padding", code: `padding: ${em}rem;` },
+      { title: "Gap", code: `gap: ${em}rem;` },
+      { title: "Border Width", code: `border-width: ${em}rem;` },
+      {
+        title: "Position",
+        code: `top: ${em}rem;\nright: ${em}rem;\nbottom: ${em}rem;\nleft: ${em}rem;`,
+      },
+    ],
+    em: [
+      { title: "Font Size", code: `font-size: ${em}em;` },
+      { title: "Height", code: `height: ${em}em;` },
+      { title: "Width", code: `width: ${em}em;` },
+      { title: "Margin", code: `margin: ${em}em;` },
+      { title: "Padding", code: `padding: ${em}em;` },
+      { title: "Gap", code: `gap: ${em}em;` },
+      { title: "Border Width", code: `border-width: ${em}em;` },
+      {
+        title: "Position",
+        code: `top: ${em}rem;\nright: ${em}rem;\nbottom: ${em}em;\nleft: ${em}rem;`,
+      },
+    ],
+    NaN: [
+      { title: "Font Size", code: "font-size: --" },
+      { title: "Height", code: "height: --" },
+      { title: "Width", code: "width: --" },
+      { title: "Margin", code: "margin: --" },
+      { title: "Padding", code: "padding: --" },
+      { title: "Gap", code: "gap: --" },
+      { title: "Border Width", code: "border-width: --" },
+      {
+        title: "Position",
+        code: `top: --\nright: --\nbottom: --\nleft: --`,
+      },
+    ],
+  };
+
+  //TabSwitcher Content
+
+  const tabButtons = ["px", "em", "rem"];
+
+  const tabContents = [
+    <div className="grid grid-cols-4 gap-4">
+      {isNaN(pixels)
+        ? CodeSamples["NaN"].map((sample) => (
+            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+          ))
+        : CodeSamples["px"].map((sample) => (
+            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+          ))}
+    </div>,
+    <div className="grid grid-cols-4 gap-4">
+      {isNaN(em)
+        ? CodeSamples["NaN"].map((sample) => (
+            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+          ))
+        : CodeSamples["em"].map((sample) => (
+            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+          ))}
+    </div>,
+    <div className="grid grid-cols-4 gap-4">
+      {isNaN(pixels)
+        ? CodeSamples["NaN"].map((sample) => (
+            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+          ))
+        : CodeSamples["rem"].map((sample) => (
+            <CodeBlock title={sample.title} code={<pre>{sample.code}</pre>} />
+          ))}
+    </div>,
+  ];
+
   // JSX for rendering the UI components.
   return (
     <>
@@ -113,7 +203,6 @@ function UnitConverter() {
         <p className="font-arial text-1xl ml-4 mb-2 text-gray-400">
           Calculate PX, REM/EM, and Tailwind utility classes with ease.
         </p>
-
         {/* Section for Input Boxes*/}
         <div className="flex gap-10 p-4 ml-52">
           <div className="mb-3">
@@ -137,7 +226,12 @@ function UnitConverter() {
               </div>
             ) : (
               <div className="flex items-center">
-                <span className="mr-2">{basePixelSize}px</span>
+                {/*Tertiary operator used to differentiate when the Base Size is NaN and Not NaN*/}
+                {isNaN(basePixelSize) ? (
+                  <span className="mr-2">--</span>
+                ) : (
+                  <span className="mr-2">{basePixelSize}px</span>
+                )}
                 <button onClick={handleCogClick}>⚙️</button>
               </div>
             )}
@@ -163,7 +257,6 @@ function UnitConverter() {
             onValueChange={handleTailwindChange}
           />
         </div>
-
         {/* Section for Lorem Ipsum Preview*/}
         <div className="flex flex-col gap-4 items-start p-4">
           <p className="font-arial text-4xl">Preview</p>
@@ -181,11 +274,15 @@ function UnitConverter() {
             </p>
           </div>
         </div>
-
         {/* Section for code blocks */}
-        <div className="grid grid-cols-4 gap-4">
-          <CodeBlock title="Font Size" code={`font-size: ${pixels}px;`} />
+
+        <div>
+          <TabSwitcher
+            buttons={tabButtons}
+            children={tabContents}
+          ></TabSwitcher>
         </div>
+
         {/* <GoDeeper linksData={linksData} /> */}
       </main>
     </>


### PR DESCRIPTION
- When you click in an input box component, the text is now automatically selected
- When the settings cog is clicked, there is auto focus and auto text selection in the base size input field now
- The code samples are now being rendered, code block component has been changed to not include the "unit" prop anymore, and they will no longer display NaN when the input boxes are empty (same with the base size display)
- The copy button has been added to the code block component and only appears when the code block is hovered on
- The lorem ipsum preview text is now editable
- A title prop has been added to the tab switcher component (talked to steven about this)
- The padding in the tab switcher and go deeper components has been updated (talked to steven about this), same with the input box div and lorem ipsum preview
- I am now using the toolheadersection and toolheading components to render the title and sub-heading, never realized that was a thing before
- The go deeper component is now rendered and the relevant links mentioned in the figma design have been added

- As discussed earlier, all of the changes related to the tailwind size will still be made
