### PR TITLE
Unit Converter Phase 5 PR (V1)

### DIFF
--- a/fetools-app/src/components/CopyButton.jsx
+++ b/fetools-app/src/components/CopyButton.jsx
@@ -1,3 +1,6 @@
+import React from "react";
+import { MdContentCopy } from "react-icons/md";
+
 function CopyButton({ onCopy }) {
   const handleCopy = () => {
     const textToCopy = onCopy();
@@ -13,7 +16,11 @@ function CopyButton({ onCopy }) {
     }
   };
 
-  return <button onClick={handleCopy}>📋</button>;
+  return (
+    <button onClick={handleCopy}>
+      <MdContentCopy />
+    </button>
+  );
 }
 
 export default CopyButton;

--- a/fetools-app/src/components/EditableInput.jsx
+++ b/fetools-app/src/components/EditableInput.jsx
@@ -1,0 +1,89 @@
+import React, { useState, useRef } from "react";
+import { MdOutlineSettings } from "react-icons/md";
+
+// EditableInput component
+function EditableInput({
+  value,
+  unit = "",
+  onChange,
+  label,
+  type = "text", // Default to text if no type is specified
+}) {
+  // State to manage whether the input is in edit mode or not
+  const [editMode, setEditMode] = useState(false);
+
+  // Reference to the input element to focus on it when entering edit mode
+  const inputRef = useRef(null);
+
+  // Function to toggle edit mode
+  const toggleEditMode = () => {
+    const newEditMode = !editMode;
+    setEditMode(newEditMode);
+    if (newEditMode) {
+      setTimeout(() => {
+        inputRef.current.focus();
+        inputRef.current.select();
+      }, 0);
+    }
+  };
+
+  // Function to handle onBlur event
+  const handleBlur = () => {
+    if (editMode) {
+      // If in edit mode, set editMode to false when the input loses focus
+      setEditMode(false);
+    }
+  };
+
+  // Function to check if the value is empty
+  function isEmpty(value) {
+    return (
+      value === undefined ||
+      value === null ||
+      (typeof value === "string" && value.trim() === "") ||
+      (typeof value === "number" && isNaN(value))
+    );
+  }
+
+  return (
+    <div className="mb-3 flex items-center">
+      {/* Label for the input */}
+      <label className="text-sm font-bold text-black mr-2">{label}</label>
+      {/*Tertiary operator used to differentiate when the input field should and should not be editable*/}
+      {editMode ? (
+        <div className="flex border rounded relative">
+          <input
+            ref={inputRef}
+            type={type}
+            value={value}
+            onChange={onChange}
+            onBlur={handleBlur}
+            className="border rounded border-black w-28 py-2 px-3  text-gray-400 leading-tight"
+          />
+          {/* Display unit next to the input if applicable*/}
+          <span className="px-2 text-gray-700 absolute inset-y-0 right-0 flex items-center mr-2 pointer-events-none font-semibold">
+            {unit}
+          </span>
+        </div>
+      ) : (
+        // Render static text when not in edit mode
+        <div className="flex items-center">
+          {isEmpty(value) ? (
+            <span className="mr-2 bg-gray-200 px-2">--</span>
+          ) : (
+            <span className="mr-2 bg-gray-200 px-2">
+              {value}
+              {unit}
+            </span>
+          )}
+          {/* Button to toggle edit mode */}
+          <button onClick={toggleEditMode} style={{ fontSize: "24px" }}>
+            <MdOutlineSettings />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default EditableInput;

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -39,7 +39,7 @@ function TextField({
         `}
       </style>
       <div className="mb-3 relative">
-        <label className="block mb-2 text-sm font-bold text-gray-400">
+        <label className="block mb-2 text-sm font-bold text-black">
           {title}
         </label>
         <div className="flex border rounded relative">

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -7,7 +7,7 @@ import CodeBlock from "../components/CodeBlock";
 import TabSwitcher from "../components/TabSwitcher";
 import EditableInput from "../components/EditableInput";
 
-import React, { useState, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { MdOutlineSettings } from "react-icons/md";
 
 // Function component UnitConverter for converting units between pixels, em/rem, and Tailwind utility classes
@@ -26,9 +26,22 @@ function UnitConverter() {
   );
 
   // Function to handle changes in the contentEditable div
+  const editableRef = useRef(null);
+
   const handleContentChange = (e) => {
-    setEditableContent(e.currentTarget.textContent);
+    const newText = editableRef.current.innerText;
+    if (newText !== editableContent) {
+      setEditableContent(newText);
+    }
   };
+
+  // Use useEffect to set the initial content of the contentEditable div
+  useEffect(() => {
+    const currentText = editableRef.current.innerText;
+    if (editableContent !== currentText) {
+      editableRef.current.innerText = editableContent;
+    }
+  }, [editableContent]);
 
   // State variable to track if the alert has been shown
   const [alertShown, setAlertShown] = useState(false);
@@ -425,12 +438,12 @@ function UnitConverter() {
           >
             <div
               contentEditable
+              ref={editableRef}
               className="font-arial font-bold text-3xl break-words leading-none focus:outline-none"
               style={{
                 fontSize: cssSize,
               }}
               onInput={handleContentChange} // Update state on input
-              dangerouslySetInnerHTML={{ __html: editableContent }}
             ></div>
           </div>
         </div>

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -7,6 +7,7 @@ import CodeBlock from "../components/CodeBlock";
 import TabSwitcher from "../components/TabSwitcher";
 
 import React, { useState, useRef } from "react";
+import { MdOutlineSettings } from "react-icons/md";
 
 // Function component UnitConverter for converting units between pixels, em/rem, and Tailwind utility classes
 
@@ -433,7 +434,9 @@ function UnitConverter() {
                 ) : (
                   <span className="mr-2">{basePixelSize}px</span>
                 )}
-                <button onClick={handleCogClick}>⚙️</button>
+                <button onClick={handleCogClick} style={{ fontSize: "24px" }}>
+                  <MdOutlineSettings />
+                </button>
               </div>
             )}
           </div>

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -5,6 +5,7 @@ import ToolHeaderSection from "../components/ToolsLayout/ToolHeaderSection";
 import TextField from "../components/TextField";
 import CodeBlock from "../components/CodeBlock";
 import TabSwitcher from "../components/TabSwitcher";
+import EditableInput from "../components/EditableInput";
 
 import React, { useState, useRef } from "react";
 import { MdOutlineSettings } from "react-icons/md";
@@ -407,8 +408,8 @@ function UnitConverter() {
         </ToolHeaderSection>
         {/* Section for Input Boxes*/}
         <div className="flex gap-10 sm:py-8 sm:px-16 lg:px-80">
-          <div className="mb-3">
-            <label className="block mb-2 text-sm font-bold text-gray-400">
+          <div className="mb-3 flex items-center">
+            <label className="text-sm font-bold text-black mr-2">
               Base Size
             </label>
             {/*Tertiary operator used to differentiate when the Base Size input element should and should not be editable*/}
@@ -430,9 +431,11 @@ function UnitConverter() {
               <div className="flex items-center">
                 {/*Tertiary operator used to differentiate when the Base Size is NaN and Not NaN*/}
                 {isNaN(basePixelSize) ? (
-                  <span className="mr-2">--</span>
+                  <span className="mr-2 bg-gray-200 px-2">--</span>
                 ) : (
-                  <span className="mr-2">{basePixelSize}px</span>
+                  <span className="mr-2 bg-gray-200 px-2">
+                    {basePixelSize}px
+                  </span>
                 )}
                 <button onClick={handleCogClick} style={{ fontSize: "24px" }}>
                   <MdOutlineSettings />
@@ -440,6 +443,15 @@ function UnitConverter() {
               </div>
             )}
           </div>
+
+          {/* <EditableInput
+            label="Base Size"
+            value={basePixelSize}
+            unit="px"
+            type="number"
+            onChange={handleBasePixelSizeChange}
+            onBlur={handleBaseSizeInputBlur}
+          /> */}
 
           <TextField
             title="REM/EM"

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -18,7 +18,6 @@ function UnitConverter() {
   const [pixels, setPixels] = useState(0);
   const [em, setEm] = useState(0);
   const [tailwindSize, setTailwindSize] = useState(0);
-  const [editMode, setEditMode] = useState(false);
   const [cssSize, setCssSize] = useState("16px");
 
   // State to hold the content of the contentEditable div
@@ -195,29 +194,6 @@ function UnitConverter() {
       newTailwindSize = tailwindSize;
     }
     setTailwindSize(tailwindCheck(formatCheck(newTailwindSize)));
-  };
-
-  // A ref to the base size input element
-  const baseSizeInputRef = useRef(null);
-
-  // Handler for the cog (settings) icon click. Toggles the edit mode state.
-  const handleCogClick = () => {
-    const newEditMode = !editMode;
-    setEditMode(newEditMode);
-    if (newEditMode) {
-      setTimeout(() => {
-        baseSizeInputRef.current.focus();
-        baseSizeInputRef.current.select();
-      }, 0);
-    }
-  };
-
-  // Handler for the input field losing focus
-  const handleBaseSizeInputBlur = () => {
-    if (editMode) {
-      // If in edit mode, set editMode to false when the input loses focus
-      setEditMode(false);
-    }
   };
 
   //links for Go Deeper component
@@ -406,52 +382,17 @@ function UnitConverter() {
             tagline="Calculate PX, REM/EM, and Tailwind utility classes with ease."
           />
         </ToolHeaderSection>
-        {/* Section for Input Boxes*/}
-        <div className="flex gap-10 sm:py-8 sm:px-16 lg:px-80">
-          <div className="mb-3 flex items-center">
-            <label className="text-sm font-bold text-black mr-2">
-              Base Size
-            </label>
-            {/*Tertiary operator used to differentiate when the Base Size input element should and should not be editable*/}
-            {editMode ? (
-              <div className="flex border rounded relative">
-                <input
-                  ref={baseSizeInputRef}
-                  type="number"
-                  className="border rounded border-black w-28 py-2 px-3  text-gray-400 leading-tight"
-                  value={basePixelSize}
-                  onChange={handleBasePixelSizeChange}
-                  onBlur={handleBaseSizeInputBlur}
-                />
-                <span className="px-2 text-gray-700 absolute inset-y-0 right-0 flex items-center mr-2 pointer-events-none font-semibold">
-                  px
-                </span>
-              </div>
-            ) : (
-              <div className="flex items-center">
-                {/*Tertiary operator used to differentiate when the Base Size is NaN and Not NaN*/}
-                {isNaN(basePixelSize) ? (
-                  <span className="mr-2 bg-gray-200 px-2">--</span>
-                ) : (
-                  <span className="mr-2 bg-gray-200 px-2">
-                    {basePixelSize}px
-                  </span>
-                )}
-                <button onClick={handleCogClick} style={{ fontSize: "24px" }}>
-                  <MdOutlineSettings />
-                </button>
-              </div>
-            )}
-          </div>
 
-          {/* <EditableInput
+        {/* Section for Input Boxes*/}
+
+        <div className="flex gap-10 sm:py-8 sm:px-16 lg:px-80">
+          <EditableInput
             label="Base Size"
             value={basePixelSize}
             unit="px"
             type="number"
             onChange={handleBasePixelSizeChange}
-            onBlur={handleBaseSizeInputBlur}
-          /> */}
+          />
 
           <TextField
             title="REM/EM"

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -81,7 +81,7 @@ function UnitConverter() {
     setBasePixelSize(newBaseSize);
     const newEm = pixels / newBaseSize;
     setEm(newEm);
-    setTailwindSize(newEm * 4);
+    setTailwindSize(TailwindCheck(newEm * 4));
   };
 
   // Handler for pixel value changes

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -61,7 +61,7 @@ function UnitConverter() {
     24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96,
   ];
 
-  const TailwindCheck = (TailwindSize) => {
+  const tailwindCheck = (TailwindSize) => {
     if (isNaN(TailwindSize) || TailwindSize === "") {
       return "";
     }
@@ -81,7 +81,7 @@ function UnitConverter() {
     setBasePixelSize(newBaseSize);
     const newEm = pixels / newBaseSize;
     setEm(newEm);
-    setTailwindSize(TailwindCheck(newEm * 4));
+    setTailwindSize(tailwindCheck(newEm * 4));
   };
 
   // Handler for pixel value changes
@@ -90,7 +90,7 @@ function UnitConverter() {
     setPixels(newPixels);
     const newEm = newPixels / basePixelSize;
     setEm(newEm);
-    setTailwindSize(TailwindCheck(newEm * 4));
+    setTailwindSize(tailwindCheck(newEm * 4));
     updateCssSize(newPixels);
   };
 
@@ -100,7 +100,7 @@ function UnitConverter() {
     setEm(newEm);
     const newPixels = newEm * basePixelSize;
     setPixels(newPixels);
-    setTailwindSize(TailwindCheck(newEm * 4));
+    setTailwindSize(tailwindCheck(newEm * 4));
     updateCssSize(newPixels);
   };
 
@@ -111,7 +111,7 @@ function UnitConverter() {
   };
 
   // Tailwind Size Format Check
-  const FormatCheck = (input) => {
+  const formatCheck = (input) => {
     // Check if input is in the allowed format [Xrem] or [Xpx], if so, return as is
     if (
       (input.startsWith("[") && input.endsWith("rem]")) ||
@@ -136,7 +136,7 @@ function UnitConverter() {
     }
 
     // Validate format
-    let formattedValue = FormatCheck(inputValue);
+    let formattedValue = formatCheck(inputValue);
 
     let newTailwindSize;
     let newEm;
@@ -194,7 +194,7 @@ function UnitConverter() {
     } else {
       newTailwindSize = tailwindSize;
     }
-    setTailwindSize(TailwindCheck(FormatCheck(newTailwindSize)));
+    setTailwindSize(tailwindCheck(formatCheck(newTailwindSize)));
   };
 
   // A ref to the base size input element


### PR DESCRIPTION
- Used react-icons library to update clipboard icon in CopyButton and Base Size gear icon in UnitConverter
- Created EditableInput component, this is the "cog" component we discussed in our meeting. The user will be able to click the cog icon to turn the static text into an editable input field, the title of the field is now on the left side to match the UI shown in the final wireframe. 
- The EditableInput component is being used in the Unit Converter for the base size field, hence alot of the code in the Unit Converter being deleted, since that state variable and the associated functions are now obsolete as they are a part of the EditableInput component
- Fixed Bug: The tailwindcheck function was not being applied to the tailwind size when a change was being made to the base size (and so this resulted in tailwind sizes that do not exist being shown)
- Fixed Bug: Cursor in text preview was being sent back to the beginning of the line when a change was made