### PR TITLE
Unit Converter Phase 5 PR (V2)

### DIFF
--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -24,11 +24,14 @@ function CodeBlock({ title, code, lang = "css" }) {
 
   return (
     <div className="mb-4 relative group">
-      <div className="mb-2 text-sm font-bold text-gray-400">{title}</div>
-      <div className="p-3 bg-gray-200 rounded relative">
-        <pre className="whitespace-pre-wrap overflow-x-auto">
-          <code>{renderCodeWithHighlight()}</code>
-        </pre>
+      <div className="mb-2 text-sm font-bold text-black">{title}</div>
+      <div className="relative rounded overflow-hidden">
+        <div className="absolute inset-y-0 left-0 w-1 bg-gray-600 z-10"></div>
+        <div className="p-3 bg-gray-200 rounded relative">
+          <pre className="whitespace-pre-wrap overflow-x-auto">
+            <code>{renderCodeWithHighlight()}</code>
+          </pre>
+        </div>
       </div>
       <div className="absolute top-0 right-0 mb-2 hidden group-hover:flex">
         <CopyButton onCopy={getCode} />

--- a/fetools-app/src/components/TabSwitcher.jsx
+++ b/fetools-app/src/components/TabSwitcher.jsx
@@ -37,7 +37,7 @@ export default function TabSwitcher({ buttons = [], children, title }) {
         id="tab-switcher-sm"
         className={buttons.length === 0 ? "" : "max-[420px]:hidden"}
       >
-        <div className="flex flex-1 justify-between ">
+        <div className="flex flex-1 justify-end mb-2">
           <fieldset className="flex flex-wrap items-center gap-x-8 mb-3">
             {radioButtons(buttons)}
           </fieldset>

--- a/fetools-app/src/components/TabSwitcher.jsx
+++ b/fetools-app/src/components/TabSwitcher.jsx
@@ -1,70 +1,82 @@
-import { useState } from "react"
+import { useState } from "react";
 import {
-    Accordion,
-    AccordionContent,
-    AccordionItem,
-    AccordionTrigger,
-} from "@/components/ui/accordion"
-  
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
-export default function TabSwitcher({buttons=[], children, title}){
+export default function TabSwitcher({ buttons = [], children, title }) {
+  const [selectedButton, setSelectedButton] = useState(buttons[0]);
+  const [displayedContent, setDisplayedContent] = useState(0);
 
-    const [ selectedButton, setSelectedButton] = useState(buttons[0])
-    const [ displayedContent, setDisplayedContent] = useState(0)
+  const radioButtons = (array) =>
+    array.map((btn, idx) => (
+      <label
+        key={`radioBtn-${idx}`}
+        id={btn}
+        name="tab-switcher-buttons"
+        className="font-bold text-sm leading-none"
+      >
+        <input
+          type="radio"
+          value={btn}
+          checked={selectedButton === btn}
+          onChange={(evt) => (
+            handleOptionChange(evt), setDisplayedContent(idx)
+          )}
+          className="inline-block align-middle mr-1"
+        />
+        <p className="inline-block leading-none">{btn}</p>
+      </label>
+    ));
 
-    const radioButtons = array => array.map((btn, idx)=>(
-            <label key={`radioBtn-${idx}`} id={btn} name="tab-switcher-buttons" 
-            className="font-bold text-sm leading-none">
-                <input type="radio" value={btn} 
-                checked={selectedButton===btn} 
-                onChange={ evt => (
-                    handleOptionChange(evt),
-                    setDisplayedContent(idx))
-                } className="inline-block align-middle mr-1"/>
-                <p className="inline-block leading-none">{btn}</p>
-            </label>
-        )
-    )
-
-    return(
-        <div id="tab-switcher" 
-        className="flex flex-col flex-1 p-6 mb-2
-        sm:p-12 lg:px-48 lg:py-20">
-            <div id="tab-switcher-sm" className={buttons.length===0?'':"max-[420px]:hidden"}>
-                <div className="flex flex-1 justify-between ">
-                    <h2 className="font-bold text-3xl leading-none">{title}</h2>
-                    <fieldset className="flex flex-wrap items-center gap-x-8">
-                        {radioButtons(buttons)}
-                    </fieldset>
-                </div>
-
-                <div className="flex-1 flex-col">
-                    {children[displayedContent]||children}
-                </div>
-            </div>
-
-            <div id="tab-switcher-mobile" className={buttons.length===0?'hidden':"min-[420px]:hidden"}>
-                <Accordion type="single" collapsible>
-                    <AccordionItem value="item-1">
-                        <AccordionTrigger 
-                        className="font-bold text-3xl leading-none">{title}</AccordionTrigger>
-                        <AccordionContent>
-                            <fieldset className="flex flex-wrap items-center gap-x-8">
-                                {radioButtons(buttons)}
-                            </fieldset>
-                        </AccordionContent>
-                    </AccordionItem>
-                </Accordion>
-
-                <div className="flex-1 flex-col mt-3">
-                    {children[displayedContent]||children}
-                </div>
-            </div>
-
+  return (
+    <div
+      id="tab-switcher"
+      className="flex flex-col flex-1 p-6 mb-2
+        sm:p-12 lg:px-48 lg:py-20"
+    >
+      <div
+        id="tab-switcher-sm"
+        className={buttons.length === 0 ? "" : "max-[420px]:hidden"}
+      >
+        <div className="flex flex-1 justify-between ">
+          <fieldset className="flex flex-wrap items-center gap-x-8 mb-3">
+            {radioButtons(buttons)}
+          </fieldset>
         </div>
-    )
 
-    function handleOptionChange(evt){
-        setSelectedButton(evt.target.value)
-    }
+        <div className="flex-1 flex-col">
+          {children[displayedContent] || children}
+        </div>
+      </div>
+
+      <div
+        id="tab-switcher-mobile"
+        className={buttons.length === 0 ? "hidden" : "min-[420px]:hidden"}
+      >
+        <Accordion type="single" collapsible>
+          <AccordionItem value="item-1">
+            <AccordionTrigger className="font-bold text-3xl leading-none">
+              {title}
+            </AccordionTrigger>
+            <AccordionContent>
+              <fieldset className="flex flex-wrap items-center gap-x-8">
+                {radioButtons(buttons)}
+              </fieldset>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+
+        <div className="flex-1 flex-col mt-3">
+          {children[displayedContent] || children}
+        </div>
+      </div>
+    </div>
+  );
+
+  function handleOptionChange(evt) {
+    setSelectedButton(evt.target.value);
+  }
 }

--- a/fetools-app/src/components/TabSwitcher.jsx
+++ b/fetools-app/src/components/TabSwitcher.jsx
@@ -32,11 +32,7 @@ export default function TabSwitcher({ buttons = [], children, title }) {
     ));
 
   return (
-    <div
-      id="tab-switcher"
-      className="flex flex-col flex-1 p-6 mb-2
-        sm:p-12 lg:px-48 lg:py-20"
-    >
+    <div id="tab-switcher" className="flex flex-col flex-1 p-3 mb-2">
       <div
         id="tab-switcher-sm"
         className={buttons.length === 0 ? "" : "max-[420px]:hidden"}

--- a/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
+++ b/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
@@ -1,9 +1,11 @@
+import { FaLink } from "react-icons/fa6";
+
 export default function GoDeeper({ linksData }) {
   const anchorElements = (array) =>
     array.map(({ url, textValue }, idx) => (
       <li key={`GoLink-${idx}`}>
-        <div className="flex items-center">
-          <span className="material-symbols-rounded text-4xl">link</span>
+        <div className="flex items-center gap-2">
+          <FaLink />
           <a
             href={url}
             className="underline underline-offset-4 text-md font-bold"

--- a/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
+++ b/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
@@ -1,23 +1,27 @@
-export default function GoDeeper({linksData}){
+export default function GoDeeper({ linksData }) {
+  const anchorElements = (array) =>
+    array.map(({ url, textValue }, idx) => (
+      <li key={`GoLink-${idx}`}>
+        <div className="flex items-center">
+          <span className="material-symbols-rounded text-4xl">link</span>
+          <a
+            href={url}
+            className="underline underline-offset-4 text-md font-bold"
+          >
+            {textValue}
+          </a>
+        </div>
+      </li>
+    ));
 
-    const anchorElements = array => array.map(({url, textValue}, idx)=> (
-          <li key={`GoLink-${idx}`}>
-              <a 
-                href={url}
-                className="underline underline-offset-4 text-md font-bold">
-                  {textValue}
-              </a>
-          </li>
-      ))
-
-    return(
-        <aside className="flex flex-col flex-1 gap-5 p-6
-        sm:p-12 lg:px-48 lg:py-20">
-            <h2 className="font-bold text-3xl leading-none">Go Deeper...</h2>
-            <ul className="flex flex-col gap-3 list-none list-inside">
-               {anchorElements(linksData)} 
-            </ul>
-        </aside>
-    )
-
+  return (
+    <aside
+      className="flex flex-col flex-1 gap-5 p-3
+        "
+    >
+      <ul className="flex flex-col gap-3 list-none list-inside">
+        {anchorElements(linksData)}
+      </ul>
+    </aside>
+  );
 }

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -309,7 +309,7 @@ function UnitConverter() {
 
   //TabSwitcher Content
 
-  const tabButtons = ["rem", "em", "px", "tailwind"];
+  const tabButtons = ["Rem", "Em", "Px", "Tailwind"];
 
   const tabContents = [
     <div key="tab-rem" className="grid grid-cols-4 gap-4">

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -49,22 +49,19 @@ function UnitConverter() {
   // Update CSS size whenever pixels, em, or Tailwind size changes
   const updateCssSize = (newSizeInPixels) => {
     let finalSize = newSizeInPixels;
+    let displayNote = false;
 
     // Check if newSizeInPixels exceeds the maximum allowed size for the preview (1000)
     if (newSizeInPixels > 1000) {
       finalSize = 1000;
-      if (!alertShown) {
-        alert(
-          "Preview is limited to 1000px. Conversion will still be accurate above this value."
-        );
-        setAlertShown(true);
-      }
+      displayNote = true;
     }
-
-    // Notify the user that the preview is capped
 
     // Check if newSizeInPixels is a number, if not, set CSS size to "0px"
     setCssSize(isNaN(finalSize) ? "0px" : `${finalSize}px`); // Update CSS size
+
+    // Update the state to control the visibility of the inline notification
+    setAlertShown(displayNote);
   };
 
   // Tailwind Size Conversions
@@ -434,6 +431,15 @@ function UnitConverter() {
         {/* Section for Lorem Ipsum Preview*/}
         <div className="flex flex-col gap-4 items-start sm:p-8 lg:px-48">
           <p className="font-arial text-4xl">Preview</p>
+
+          {/* Inline Notification about Preview Limit */}
+          {alertShown && (
+            <div className="text-center py-2 px-4 bg-yellow-100 text-yellow-800 rounded-md">
+              Preview is limited to 1000px. Conversion will still be accurate
+              above this value.
+            </div>
+          )}
+
           <div
             className="flex flex-row justify-start items-center border border-black border-dashed p-3 
         min-h-[100px] w-full overflow-auto"

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -69,11 +69,11 @@ function UnitConverter() {
   useEffect(() => {
     const size = parseInt(cssSize); // Parse only the numeric part of cssSize
     if (!isNaN(size) && size > 0) {
-      const lineThickness = 1;
+      const lineThickness = 0.5;
       const backgroundStyle = {
         backgroundImage: `
-          linear-gradient(to right, lightgray ${lineThickness}px, transparent ${lineThickness}px),
-          linear-gradient(to bottom, lightgray ${lineThickness}px, transparent ${lineThickness}px)`,
+          linear-gradient(to right, #d8b8ff ${lineThickness}px, transparent ${lineThickness}px),
+          linear-gradient(to bottom, #d8b8ff ${lineThickness}px, transparent ${lineThickness}px)`,
         backgroundSize: `${size}px ${size}px`,
       };
       setGridBackgroundStyle(backgroundStyle);

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -394,10 +394,10 @@ function UnitConverter() {
         </ToolHeaderSection>
 
         <PageSection icon="Calculate" title="Calculator" className="w-full">
-          <div className="flex gap-10 mt-2">
+          <div className="flex gap-2 mt-2 flex-wrap">
             {/*Text Preview*/}
 
-            <div className="flex flex-col gap-4 items-start sm:p-8 lg:px-40">
+            <div className="flex flex-col w-1/2 gap-4 items-start">
               {/* Inline Notification about Preview Limit */}
 
               {alertShown && (
@@ -407,10 +407,7 @@ function UnitConverter() {
                 </div>
               )}
 
-              <div
-                className="flex flex-row justify-start items-center p-3 
-        min-h-[100px] w-full overflow-auto"
-              >
+              <div className="flex flex-row justify-center items-center p-3 min-h-[100px] max-h-[500px] w-full overflow-auto">
                 <div
                   contentEditable
                   ref={editableRef}
@@ -424,35 +421,41 @@ function UnitConverter() {
             </div>
 
             {/*Input Boxes*/}
-            <EditableInput
-              label="Base Size"
-              value={basePixelSize}
-              unit="px"
-              type="number"
-              onChange={handleBasePixelSizeChange}
-            />
+            <div className="flex flex-col gap-10">
+              <div className="flex gap-8">
+                <TextField
+                  title="REM/EM"
+                  value={em}
+                  unit="rem"
+                  onValueChange={handleEmChange}
+                />
 
-            <TextField
-              title="REM/EM"
-              value={em}
-              unit="rem"
-              onValueChange={handleEmChange}
-            />
+                <TextField
+                  title="Pixels"
+                  value={pixels}
+                  unit="px"
+                  onValueChange={handlePixelChange}
+                />
 
-            <TextField
-              title="Pixels"
-              value={pixels}
-              unit="px"
-              onValueChange={handlePixelChange}
-            />
+                <TextField
+                  title="Tailwind Size"
+                  value={tailwindSize}
+                  onValueChange={handleTailwindChange}
+                  inputType="text"
+                  onBlur={onTailwindBlur}
+                />
+              </div>
 
-            <TextField
-              title="Tailwind Size"
-              value={tailwindSize}
-              onValueChange={handleTailwindChange}
-              inputType="text"
-              onBlur={onTailwindBlur}
-            />
+              <div className="flex justify-center items-center">
+                <EditableInput
+                  label="Base Size"
+                  value={basePixelSize}
+                  unit="px"
+                  type="number"
+                  onChange={handleBasePixelSizeChange}
+                />
+              </div>
+            </div>
           </div>
         </PageSection>
 

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -9,7 +9,6 @@ import EditableInput from "../components/EditableInput";
 import PageSection from "../components/PageLayout/PageSection";
 
 import React, { useState, useEffect, useRef } from "react";
-import { MdOutlineSettings } from "react-icons/md";
 
 // Function component UnitConverter for converting units between pixels, em/rem, and Tailwind utility classes
 

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -21,9 +21,7 @@ function UnitConverter() {
   const [cssSize, setCssSize] = useState("16px");
 
   // State to hold the content of the contentEditable div
-  const [editableContent, setEditableContent] = useState(
-    "Lorem ipsum dolor sit amet"
-  );
+  const [editableContent, setEditableContent] = useState("Aa");
 
   // Function to handle changes in the contentEditable div
   const editableRef = useRef(null);
@@ -395,66 +393,69 @@ function UnitConverter() {
           />
         </ToolHeaderSection>
 
-        {/* Section for Input Boxes*/}
+        <PageSection icon="Calculate" title="Calculator" className="w-full">
+          <div className="flex gap-10 mt-2">
+            {/*Text Preview*/}
 
-        <div className="flex gap-10 sm:py-8 sm:px-16 lg:px-80">
-          <EditableInput
-            label="Base Size"
-            value={basePixelSize}
-            unit="px"
-            type="number"
-            onChange={handleBasePixelSizeChange}
-          />
+            <div className="flex flex-col gap-4 items-start sm:p-8 lg:px-40">
+              {/* Inline Notification about Preview Limit */}
 
-          <TextField
-            title="REM/EM"
-            value={em}
-            unit="rem"
-            onValueChange={handleEmChange}
-          />
+              {alertShown && (
+                <div className="text-center py-2 px-4 bg-yellow-100 text-yellow-800 rounded-md">
+                  Preview is limited to 1000px. Conversion will still be
+                  accurate above this value.
+                </div>
+              )}
 
-          <TextField
-            title="Pixels"
-            value={pixels}
-            unit="px"
-            onValueChange={handlePixelChange}
-          />
-
-          <TextField
-            title="Tailwind Size"
-            value={tailwindSize}
-            onValueChange={handleTailwindChange}
-            inputType="text"
-            onBlur={onTailwindBlur}
-          />
-        </div>
-        {/* Section for Lorem Ipsum Preview*/}
-        <div className="flex flex-col gap-4 items-start sm:p-8 lg:px-48">
-          <p className="font-arial text-4xl">Preview</p>
-
-          {/* Inline Notification about Preview Limit */}
-          {alertShown && (
-            <div className="text-center py-2 px-4 bg-yellow-100 text-yellow-800 rounded-md">
-              Preview is limited to 1000px. Conversion will still be accurate
-              above this value.
-            </div>
-          )}
-
-          <div
-            className="flex flex-row justify-start items-center border border-black border-dashed p-3 
+              <div
+                className="flex flex-row justify-start items-center p-3 
         min-h-[100px] w-full overflow-auto"
-          >
-            <div
-              contentEditable
-              ref={editableRef}
-              className="font-arial font-bold text-3xl break-words leading-none focus:outline-none"
-              style={{
-                fontSize: cssSize,
-              }}
-              onInput={handleContentChange} // Update state on input
-            ></div>
+              >
+                <div
+                  contentEditable
+                  ref={editableRef}
+                  className="font-arial font-bold text-3xl break-words leading-none focus:outline-none"
+                  style={{
+                    fontSize: cssSize,
+                  }}
+                  onInput={handleContentChange} // Update state on input
+                ></div>
+              </div>
+            </div>
+
+            {/*Input Boxes*/}
+            <EditableInput
+              label="Base Size"
+              value={basePixelSize}
+              unit="px"
+              type="number"
+              onChange={handleBasePixelSizeChange}
+            />
+
+            <TextField
+              title="REM/EM"
+              value={em}
+              unit="rem"
+              onValueChange={handleEmChange}
+            />
+
+            <TextField
+              title="Pixels"
+              value={pixels}
+              unit="px"
+              onValueChange={handlePixelChange}
+            />
+
+            <TextField
+              title="Tailwind Size"
+              value={tailwindSize}
+              onValueChange={handleTailwindChange}
+              inputType="text"
+              onBlur={onTailwindBlur}
+            />
           </div>
-        </div>
+        </PageSection>
+
         {/* Section for code blocks */}
 
         <div>

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -6,6 +6,7 @@ import TextField from "../components/TextField";
 import CodeBlock from "../components/CodeBlock";
 import TabSwitcher from "../components/TabSwitcher";
 import EditableInput from "../components/EditableInput";
+import PageSection from "../components/PageLayout/PageSection";
 
 import React, { useState, useEffect, useRef } from "react";
 import { MdOutlineSettings } from "react-icons/md";
@@ -309,10 +310,10 @@ function UnitConverter() {
 
   //TabSwitcher Content
 
-  const tabButtons = ["px", "em", "rem", "tailwind"];
+  const tabButtons = ["rem", "em", "px", "tailwind"];
 
   const tabContents = [
-    <div key="tab-px" className="grid grid-cols-4 gap-4">
+    <div key="tab-rem" className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
         ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
@@ -321,7 +322,7 @@ function UnitConverter() {
               code={sample.code}
             />
           ))
-        : CodeSamples["px"].map((sample, index) => (
+        : CodeSamples["rem"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -329,6 +330,7 @@ function UnitConverter() {
             />
           ))}
     </div>,
+
     <div key="tab-em" className="grid grid-cols-4 gap-4">
       {isNaN(em)
         ? CodeSamples["NaN"].map((sample, index) => (
@@ -347,7 +349,7 @@ function UnitConverter() {
           ))}
     </div>,
 
-    <div key="tab-rem" className="grid grid-cols-4 gap-4">
+    <div key="tab-px" className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
         ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
@@ -356,7 +358,7 @@ function UnitConverter() {
               code={sample.code}
             />
           ))
-        : CodeSamples["rem"].map((sample, index) => (
+        : CodeSamples["px"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -364,6 +366,7 @@ function UnitConverter() {
             />
           ))}
     </div>,
+
     <div key="tab-tailwind" className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
         ? CodeSamples["NaNtailwind"].map((sample, index) => (
@@ -450,11 +453,16 @@ function UnitConverter() {
         {/* Section for code blocks */}
 
         <div>
-          <TabSwitcher
-            buttons={tabButtons}
-            children={tabContents}
-            title="Code Samples"
-          ></TabSwitcher>
+          <PageSection
+            icon="integration_instructions"
+            title="Code Snippets"
+            className="w-full "
+          >
+            <TabSwitcher
+              buttons={tabButtons}
+              children={tabContents}
+            ></TabSwitcher>
+          </PageSection>
         </div>
 
         <GoDeeper linksData={linksData} />

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -465,7 +465,9 @@ function UnitConverter() {
           </PageSection>
         </div>
 
-        <GoDeeper linksData={linksData} />
+        <PageSection title="Go Deeper" icon="school">
+          <GoDeeper linksData={linksData} />
+        </PageSection>
       </main>
     </>
   );

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -62,6 +62,26 @@ function UnitConverter() {
     setAlertShown(displayNote);
   };
 
+  // State hook for the grid background style
+  const [gridBackgroundStyle, setGridBackgroundStyle] = useState({});
+
+  //Update the grid background style when cssSize changes using useEffect hook
+  useEffect(() => {
+    const size = parseInt(cssSize); // Parse only the numeric part of cssSize
+    if (!isNaN(size) && size > 0) {
+      const lineThickness = 1;
+      const backgroundStyle = {
+        backgroundImage: `
+          linear-gradient(to right, lightgray ${lineThickness}px, transparent ${lineThickness}px),
+          linear-gradient(to bottom, lightgray ${lineThickness}px, transparent ${lineThickness}px)`,
+        backgroundSize: `${size}px ${size}px`,
+      };
+      setGridBackgroundStyle(backgroundStyle);
+    } else {
+      setGridBackgroundStyle({});
+    }
+  }, [cssSize]);
+
   // Tailwind Size Conversions
   const tailwindSizes = [
     0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 16, 20,
@@ -407,7 +427,10 @@ function UnitConverter() {
                 </div>
               )}
 
-              <div className="flex flex-row justify-center items-center p-3 min-h-[100px] max-h-[500px] w-full overflow-auto">
+              <div
+                className="flex flex-row justify-center items-center p-3 h-full w-full overflow-auto"
+                style={gridBackgroundStyle}
+              >
                 <div
                   contentEditable
                   ref={editableRef}


### PR DESCRIPTION
Hi Joe,

Here is the PR I made mid-week if you want an update on those changes: https://github.com/chingu-voyages/v47-tier2-team-17/pull/64

**Below are the details for the new changes:**

- Updated GoDeeper component to remove title prop (because section component has one), decrease padding, and add link icon beside each hyperlink
- Updated TabSwitcher component to make the buttons appear on the right side, changed padding, removed title prop
- Updated CodeBlock component to have the dark grey strip as seen in the wireframe
- Changed text preview max size alert to be a note that appears above the preview rather than an alert
- Put every section in it's own page section component
- Put the text preview and "calculator" sections beside each other
- Created a grid background for the text preview that displays the unit size size

**Note:**
- The preview and calculator are currently both in the page section component, I'll update this to use the new component you make when that is ready

**Important Remaining Tasks:**

- Update Calculator/Preview section to match the wireframe UI completely
- Optimize UI for tablet/mobile displays (may ask you questions about this as I'm pretty inexperienced on this)
- Add toasts for arbitrary rem changes - will follow up with steven, Toast component wasn't ready last week

**Questions:**

- Currently, if you write a long number in the rem/px input fields, they get covered by the "rem" or "px" label, what do you think would be the best fix for this?
- I will look into this tomorrow but I couldn't find a way to make the grid a dotted line like it is in the wireframe, if you have a good suggestion for this, let me know!

Other than that, if you notice anything I should change or add, or if I'm missing anything, please let me know! 

Thanks
