### PR TITLE
Unit Converter Phase 6 PR

### DIFF
--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -27,14 +27,14 @@ function CodeBlock({ toastState, title, code, lang = "css" }) {
       <div className="mb-2 text-sm font-bold text-black">{title}</div>
       <div className="relative rounded overflow-hidden">
         <div className="absolute inset-y-0 left-0 w-1 bg-gray-600 z-10"></div>
-        <div className="p-3 bg-gray-200 rounded relative">
+        <div className="p-3 bg-neutral-100 rounded relative">
           <pre className="whitespace-pre-wrap overflow-x-auto">
             <code>{renderCodeWithHighlight()}</code>
           </pre>
         </div>
       </div>
       <div className="absolute top-0 right-0 mb-2 hidden group-hover:flex">
-        <CopyButton onCopy={getCode} toastState={toastState}/>
+        <CopyButton onCopy={getCode} toastState={toastState} />
       </div>
     </div>
   );

--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -26,7 +26,7 @@ function CodeBlock({ toastState, title, code, lang = "css" }) {
       <div className="mb-2 text-sm font-bold text-black">{title}</div>
       <div className="relative rounded overflow-hidden">
         <div className="absolute inset-y-0 left-0 w-1 bg-gray-600 z-10"></div>
-        <div className="p-3 bg-neutral-100 rounded relative">
+        <div className="p-3 bg-neutral-100 rounded relative border border-gray-300">
           <pre className="whitespace-pre-wrap overflow-x-auto">
             <code>{renderCodeWithHighlight()}</code>
           </pre>

--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -8,13 +8,23 @@ function CodeBlock({ toastState, title, code, lang = "css" }) {
     if (lang === "css") {
       // Split code by lines for multiline code handling (for "position" attribute code)
       return code.split("\n").map((line, index) => {
-        const [property, value] = line.split(":");
-        return (
-          <div key={index}>
-            <span className="text-purple-800">{property}:</span>
-            <span className="text-black">{value}</span>
-          </div>
-        );
+        // Check if the line contains a colon
+        if (!line.includes(":")) {
+          // Render these lines without splitting
+          return (
+            <div key={index}>
+              <span className="text-purple-800">{line}</span>
+            </div>
+          );
+        } else {
+          const [property, value] = line.split(":");
+          return (
+            <div key={index}>
+              <span className="text-purple-800">{property}:</span>
+              <span className="text-black">{value}</span>
+            </div>
+          );
+        }
       });
     }
     // Default or when lang is 'tailwind'

--- a/fetools-app/src/components/CodeBlock.jsx
+++ b/fetools-app/src/components/CodeBlock.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import CopyButton from "./CopyButton";
 
 function CodeBlock({ toastState, title, code, lang = "css" }) {

--- a/fetools-app/src/components/EditableInput.jsx
+++ b/fetools-app/src/components/EditableInput.jsx
@@ -58,7 +58,7 @@ function EditableInput({
             value={value}
             onChange={onChange}
             onBlur={handleBlur}
-            className="border rounded border-black w-28 py-2 px-3  text-gray-400 leading-tight"
+            className="border rounded border-black w-28 py-2 px-3 pr-12 text-center text-gray-400 leading-tight"
           />
           {/* Display unit next to the input if applicable*/}
           <span className="px-2 text-gray-700 absolute inset-y-0 right-0 flex items-center mr-2 pointer-events-none font-semibold">

--- a/fetools-app/src/components/TabSwitcher.jsx
+++ b/fetools-app/src/components/TabSwitcher.jsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState } from "react";
 
 export default function TabSwitcher({ buttons = [], children }) {
   const [selectedButton, setSelectedButton] = useState(buttons[0]);
   const [displayedContent, setDisplayedContent] = useState(0);
 
-  const radioButtons = array =>
+  const radioButtons = (array) =>
     array.map((btn, idx) => (
       <label
         key={`radioBtn-${idx}`}
@@ -16,7 +16,9 @@ export default function TabSwitcher({ buttons = [], children }) {
           type="radio"
           value={btn}
           checked={selectedButton === btn}
-          onChange={evt => (handleOptionChange(evt), setDisplayedContent(idx))}
+          onChange={(evt) => (
+            handleOptionChange(evt), setDisplayedContent(idx)
+          )}
           className="inline-block mr-3 align-middle"
         />
         <p className="inline-block leading-none">{btn}</p>
@@ -26,7 +28,7 @@ export default function TabSwitcher({ buttons = [], children }) {
   return (
     <div id="tab-switcher" className="flex flex-col flex-1 p-3 mb-2 lg:-mt-12">
       <div className="flex justify-end flex-1 mb-2 lg:mb-8">
-        <fieldset className="flex flex-wrap items-center mb-3 gap-x-8">
+        <fieldset className="flex flex-wrap items-center mb-3 gap-x-5 md:gap-x-8">
           {radioButtons(buttons)}
         </fieldset>
       </div>

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -47,9 +47,9 @@ function TextField({
           <input
             ref={inputRef}
             type={inputType}
-            className={`py-2 pl-3 leading-tight text-gray-400 border border-black rounded w-28 focus:outline-none focus:shadow-outline ${
+            className={`py-2 pl-3 leading-tight text-gray-400 border border-black rounded w-64 focus:outline-none focus:shadow-outline ${
               unit ? "pr-12" : "pr-3"
-            }`}
+            } md:w-28`}
             value={value}
             onChange={onValueChange}
             onFocus={handleInputClick}

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -47,7 +47,7 @@ function TextField({
           <input
             ref={inputRef}
             type={inputType}
-            className={`py-2 pl-3 leading-tight text-gray-400 border border-black rounded w-64 focus:outline-none focus:shadow-outline ${
+            className={`py-2 pl-3 leading-tight text-gray-400 border text-center border-black rounded w-80 focus:outline-none focus:shadow-outline ${
               unit ? "pr-12" : "pr-3"
             } md:w-28`}
             value={value}

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -39,17 +39,17 @@ function TextField({
           }
         `}
       </style>
-      <div className="relative mb-3">
+      <div className="relative mb-3 w-full px-2 md:px-0">
         <label className="block mb-2 text-sm font-bold text-black">
           {title}
         </label>
-        <div className="relative flex border rounded">
+        <div className="relative flex border rounded w-full">
           <input
             ref={inputRef}
             type={inputType}
-            className={`py-2 pl-3 leading-tight text-gray-400 border text-center border-black rounded w-80 focus:outline-none focus:shadow-outline ${
+            className={`py-2 pl-3 leading-tight text-gray-400 border text-center border-black rounded w-full focus:outline-none focus:shadow-outline ${
               unit ? "pr-12" : "pr-3"
-            } md:w-28`}
+            }`}
             value={value}
             onChange={onValueChange}
             onFocus={handleInputClick}

--- a/fetools-app/src/components/TextField.jsx
+++ b/fetools-app/src/components/TextField.jsx
@@ -1,13 +1,14 @@
-import { useRef } from 'react';
-import CopyButton from './CopyButton';
+import { useRef } from "react";
+import CopyButton from "./CopyButton";
 
 function TextField({
   title,
   value,
   unit,
   onValueChange,
-  inputType = 'number',
+  inputType = "number",
   onBlur,
+  toastState,
 }) {
   // A ref to the input element
   const inputRef = useRef(null);
@@ -47,7 +48,7 @@ function TextField({
             ref={inputRef}
             type={inputType}
             className={`py-2 pl-3 leading-tight text-gray-400 border border-black rounded w-28 focus:outline-none focus:shadow-outline ${
-              unit ? 'pr-12' : 'pr-3'
+              unit ? "pr-12" : "pr-3"
             }`}
             value={value}
             onChange={onValueChange}
@@ -60,7 +61,7 @@ function TextField({
             </span>
           )}
           <span className="absolute top-0 right-0 -mt-2 text-lg transform translate-x-1/2 -translate-y-full">
-            <CopyButton onCopy={getValueWithUnit} />
+            <CopyButton onCopy={getValueWithUnit} toastState={toastState} />
           </span>
         </div>
       </div>

--- a/fetools-app/src/components/ToastNotification.jsx
+++ b/fetools-app/src/components/ToastNotification.jsx
@@ -1,13 +1,16 @@
-import { Root, Title, Description } from '@radix-ui/react-toast';
-import { MdColorize, MdContentCopy } from 'react-icons/md';
+import { Root, Title, Description } from "@radix-ui/react-toast";
+import { MdColorize, MdContentCopy, MdError } from "react-icons/md";
 
-export default function ToastNotification({toastContent, setOpenToast, openToast}){
-  
-  const {title, content, icon, addOn} = toastContent
-  return(
+export default function ToastNotification({
+  toastContent,
+  setOpenToast,
+  openToast,
+}) {
+  const { title, content, icon, addOn } = toastContent;
+  return (
     <Root
-    type='foreground'
-    className={`pointer-events-auto
+      type="foreground"
+      className={`pointer-events-auto
     ToastRoot max-sm:ToastTop sm:ToastBottom
     relative bg-white rounded-md text-black w-[360px] max-[380px]:w-full m-auto px-12 py-4 border border-gray-300
     shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] 
@@ -17,42 +20,50 @@ export default function ToastNotification({toastContent, setOpenToast, openToast
     data-[swipe=move]:translate-y-[var(--radix-toast-swipe-move-y)] 
     data-[swipe=cancel]:translate-y-0 
     data-[swipe=cancel]:transition-[transform_200ms_ease-out]`}
-    open={openToast}
-    onOpenChange={setOpenToast}>
-      <span className='absolute left-5 top-5 text-gray-500'>{getIcon(icon)}</span>
+      open={openToast}
+      onOpenChange={setOpenToast}
+    >
+      <span className="absolute left-5 top-5 text-gray-500">
+        {getIcon(icon)}
+      </span>
       <div>
-      <Title className="mb-[5px] font-sm font-bold">
-        {title}
-      </Title>
-      <Description asChild>
-        <div className='relative flex'>
-          <span className='flex-1'>{content}</span>
-          {getAddOn()}
-        </div>
-      </Description>
+        <Title className="mb-[5px] font-sm font-bold">{title}</Title>
+        <Description asChild>
+          <div className="relative flex">
+            <span className="flex-1">{content}</span>
+            {getAddOn()}
+          </div>
+        </Description>
       </div>
     </Root>
   );
 
-
-  function getIcon(iconType){
+  function getIcon(iconType) {
     switch (iconType) {
-      case 'copy':
-        return (<MdContentCopy/>)   
-      case 'eyedrop':
-        return (<MdColorize/>)   
+      case "copy":
+        return <MdContentCopy />;
+      case "eyedrop":
+        return <MdColorize />;
+      case "error":
+        return <MdError />;
       default:
         break;
     }
   }
 
-  function getAddOn(){
-    if(!addOn){return}
+  function getAddOn() {
+    if (!addOn) {
+      return;
+    }
     switch (addOn.type) {
-      case 'color-dot':
+      case "color-dot":
+        return (
+          <span
+            className="absolute right-0 bottom-2 flex-2 w-10 h-10 rounded-full"
+            style={{ backgroundColor: addOn.color }}
+          ></span>
+        );
 
-        return (<span className='absolute right-0 bottom-2 flex-2 w-10 h-10 rounded-full' style={{backgroundColor: addOn.color}}></span>)
-    
       default:
         break;
     }

--- a/fetools-app/src/components/UnitConverter/Calculator.jsx
+++ b/fetools-app/src/components/UnitConverter/Calculator.jsx
@@ -17,8 +17,8 @@ export default function Calculator({
   return (
     <ToolPane title="Calculator" icon="calculate">
       {/*Input Boxes*/}
-      <div className="flex flex-col gap-10 items-center">
-        <div className="flex flex-col md:flex-row gap-4 items-center">
+      <div className="flex flex-col gap-10">
+        <div className="flex flex-col gap-4 items-center md:flex-row">
           <TextField
             title="REM/EM"
             value={em}
@@ -53,7 +53,7 @@ export default function Calculator({
           />
         </div>
 
-        <div className="flex items-center justify-center">
+        <div className="flex justify-center">
           <EditableInput
             label="Base Size"
             value={basePixelSize}

--- a/fetools-app/src/components/UnitConverter/Calculator.jsx
+++ b/fetools-app/src/components/UnitConverter/Calculator.jsx
@@ -18,7 +18,7 @@ export default function Calculator({
     <ToolPane title="Calculator" icon="calculate">
       {/*Input Boxes*/}
       <div className="flex flex-col gap-10 items-center">
-        <div className="flex gap-4 items-center">
+        <div className="flex flex-col md:flex-row gap-4 items-center">
           <TextField
             title="REM/EM"
             value={em}

--- a/fetools-app/src/components/UnitConverter/Calculator.jsx
+++ b/fetools-app/src/components/UnitConverter/Calculator.jsx
@@ -27,7 +27,9 @@ export default function Calculator({
             toastState={toastState}
           />
 
-          <span className="material-symbols-rounded">autorenew</span>
+          <span className="material-symbols-rounded text-gray-400">
+            autorenew
+          </span>
 
           <TextField
             title="Pixels"
@@ -37,7 +39,9 @@ export default function Calculator({
             toastState={toastState}
           />
 
-          <span className="material-symbols-rounded">autorenew</span>
+          <span className="material-symbols-rounded text-gray-400">
+            autorenew
+          </span>
 
           <TextField
             title="Tailwind Size"

--- a/fetools-app/src/components/UnitConverter/Calculator.jsx
+++ b/fetools-app/src/components/UnitConverter/Calculator.jsx
@@ -1,6 +1,6 @@
-import TextField from '../TextField';
-import EditableInput from '../EditableInput';
-import { ToolPane } from '../ToolsLayout/Sections/';
+import TextField from "../TextField";
+import EditableInput from "../EditableInput";
+import { ToolPane } from "../ToolsLayout/Sections/";
 
 export default function Calculator({
   em,
@@ -16,8 +16,8 @@ export default function Calculator({
   return (
     <ToolPane title="Calculator" icon="calculate">
       {/*Input Boxes*/}
-      <div className="flex flex-col gap-10">
-        <div className="flex gap-8">
+      <div className="flex flex-col gap-10 items-center">
+        <div className="flex gap-4 items-center">
           <TextField
             title="REM/EM"
             value={em}
@@ -25,12 +25,16 @@ export default function Calculator({
             onValueChange={handleEmChange}
           />
 
+          <span class="material-symbols-rounded">autorenew</span>
+
           <TextField
             title="Pixels"
             value={pixels}
             unit="px"
             onValueChange={handlePixelChange}
           />
+
+          <span class="material-symbols-rounded">autorenew</span>
 
           <TextField
             title="Tailwind Size"

--- a/fetools-app/src/components/UnitConverter/Calculator.jsx
+++ b/fetools-app/src/components/UnitConverter/Calculator.jsx
@@ -12,6 +12,7 @@ export default function Calculator({
   onTailwindBlur,
   basePixelSize,
   handleBasePixelSizeChange,
+  toastState,
 }) {
   return (
     <ToolPane title="Calculator" icon="calculate">
@@ -23,6 +24,7 @@ export default function Calculator({
             value={em}
             unit="rem"
             onValueChange={handleEmChange}
+            toastState={toastState}
           />
 
           <span class="material-symbols-rounded">autorenew</span>
@@ -32,6 +34,7 @@ export default function Calculator({
             value={pixels}
             unit="px"
             onValueChange={handlePixelChange}
+            toastState={toastState}
           />
 
           <span class="material-symbols-rounded">autorenew</span>
@@ -42,6 +45,7 @@ export default function Calculator({
             onValueChange={handleTailwindChange}
             inputType="text"
             onBlur={onTailwindBlur}
+            toastState={toastState}
           />
         </div>
 

--- a/fetools-app/src/components/UnitConverter/Calculator.jsx
+++ b/fetools-app/src/components/UnitConverter/Calculator.jsx
@@ -27,7 +27,7 @@ export default function Calculator({
             toastState={toastState}
           />
 
-          <span class="material-symbols-rounded">autorenew</span>
+          <span className="material-symbols-rounded">autorenew</span>
 
           <TextField
             title="Pixels"
@@ -37,7 +37,7 @@ export default function Calculator({
             toastState={toastState}
           />
 
-          <span class="material-symbols-rounded">autorenew</span>
+          <span className="material-symbols-rounded">autorenew</span>
 
           <TextField
             title="Tailwind Size"

--- a/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
+++ b/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
@@ -65,7 +65,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
         title: "Font Size",
         code: remToTailwindFontSizeMap[em]
           ? remToTailwindFontSizeMap[em]
-          : `text-[${em.toFixed(3)}rem]`,
+          : `text-[${parseFloat(em).toFixed(3)}rem]`,
       },
       { title: "Height", code: `h-${tailwindSize}` },
       { title: "Width", code: `w-${tailwindSize}` },

--- a/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
+++ b/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
@@ -134,7 +134,10 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
           ))}
     </div>,
 
-    <div key="tab-em" className="grid grid-cols-4 gap-4">
+    <div
+      key="tab-em"
+      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4"
+    >
       {isNaN(em)
         ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
@@ -154,7 +157,10 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
           ))}
     </div>,
 
-    <div key="tab-px" className="grid grid-cols-4 gap-4">
+    <div
+      key="tab-px"
+      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4"
+    >
       {isNaN(pixels)
         ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
@@ -174,7 +180,10 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
           ))}
     </div>,
 
-    <div key="tab-tailwind" className="grid grid-cols-4 gap-4">
+    <div
+      key="tab-tailwind"
+      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4"
+    >
       {isNaN(pixels)
         ? CodeSamples["NaNtailwind"].map((sample, index) => (
             <CodeBlock

--- a/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
+++ b/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
@@ -111,7 +111,10 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
   //TabSwitcher Content
 
   const tabContents = [
-    <div key="tab-rem" className="grid grid-cols-4 gap-4">
+    <div
+      key="tab-rem"
+      className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-4 gap-4"
+    >
       {isNaN(pixels)
         ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock

--- a/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
+++ b/fetools-app/src/components/UnitConverter/CodeSnippets.jsx
@@ -1,97 +1,119 @@
-import CodeBlock from '../CodeBlock';
-import TabSwitcher from '../TabSwitcher';
+import CodeBlock from "../CodeBlock";
+import TabSwitcher from "../TabSwitcher";
 
 export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
+  const remToTailwindFontSizeMap = {
+    0.75: "text-xs",
+    0.875: "text-sm",
+    1: "text-base",
+    1.125: "text-lg",
+    1.25: "text-xl",
+    1.5: "text-2xl",
+    1.875: "text-3xl",
+    2.25: "text-4xl",
+    3: "text-5xl",
+    3.75: "text-6xl",
+    4.5: "text-7xl",
+    6: "text-8xl",
+    8: "text-9xl",
+    // Add other mappings as needed
+  };
+
   //All Code Samples
   const CodeSamples = {
     px: [
-      { title: 'Font Size', code: `font-size: ${pixels}px;` },
-      { title: 'Height', code: `height: ${pixels}px;` },
-      { title: 'Width', code: `width: ${pixels}px;` },
-      { title: 'Margin', code: `margin: ${pixels}px;` },
-      { title: 'Padding', code: `padding: ${pixels}px;` },
-      { title: 'Gap', code: `gap: ${pixels}px;` },
-      { title: 'Border Width', code: `border-width: ${pixels}px;` },
+      { title: "Font Size", code: `font-size: ${pixels}px;` },
+      { title: "Height", code: `height: ${pixels}px;` },
+      { title: "Width", code: `width: ${pixels}px;` },
+      { title: "Margin", code: `margin: ${pixels}px;` },
+      { title: "Padding", code: `padding: ${pixels}px;` },
+      { title: "Gap", code: `gap: ${pixels}px;` },
+      { title: "Border Width", code: `border-width: ${pixels}px;` },
       {
-        title: 'Position',
+        title: "Position",
         code: `top: ${pixels}px;\nright: ${pixels}px;\nbottom: ${pixels}px;\nleft: ${pixels}px;`,
       },
     ],
     rem: [
-      { title: 'Font Size', code: `font-size: ${em}rem;` },
-      { title: 'Height', code: `height: ${em}rem;` },
-      { title: 'Width', code: `width: ${em}rem;` },
-      { title: 'Margin', code: `margin: ${em}rem;` },
-      { title: 'Padding', code: `padding: ${em}rem;` },
-      { title: 'Gap', code: `gap: ${em}rem;` },
-      { title: 'Border Width', code: `border-width: ${em}rem;` },
+      { title: "Font Size", code: `font-size: ${em}rem;` },
+      { title: "Height", code: `height: ${em}rem;` },
+      { title: "Width", code: `width: ${em}rem;` },
+      { title: "Margin", code: `margin: ${em}rem;` },
+      { title: "Padding", code: `padding: ${em}rem;` },
+      { title: "Gap", code: `gap: ${em}rem;` },
+      { title: "Border Width", code: `border-width: ${em}rem;` },
       {
-        title: 'Position',
+        title: "Position",
         code: `top: ${em}rem;\nright: ${em}rem;\nbottom: ${em}rem;\nleft: ${em}rem;`,
       },
     ],
     em: [
-      { title: 'Font Size', code: `font-size: ${em}em;` },
-      { title: 'Height', code: `height: ${em}em;` },
-      { title: 'Width', code: `width: ${em}em;` },
-      { title: 'Margin', code: `margin: ${em}em;` },
-      { title: 'Padding', code: `padding: ${em}em;` },
-      { title: 'Gap', code: `gap: ${em}em;` },
-      { title: 'Border Width', code: `border-width: ${em}em;` },
+      { title: "Font Size", code: `font-size: ${em}em;` },
+      { title: "Height", code: `height: ${em}em;` },
+      { title: "Width", code: `width: ${em}em;` },
+      { title: "Margin", code: `margin: ${em}em;` },
+      { title: "Padding", code: `padding: ${em}em;` },
+      { title: "Gap", code: `gap: ${em}em;` },
+      { title: "Border Width", code: `border-width: ${em}em;` },
       {
-        title: 'Position',
+        title: "Position",
         code: `top: ${em}rem;\nright: ${em}rem;\nbottom: ${em}em;\nleft: ${em}rem;`,
       },
     ],
     tailwind: [
-      { title: 'Font Size', code: `text-${tailwindSize}` },
-      { title: 'Height', code: `h-${tailwindSize}` },
-      { title: 'Width', code: `w-${tailwindSize}` },
-      { title: 'Margin', code: `m-${tailwindSize}` },
-      { title: 'Padding', code: `p-${tailwindSize}` },
-      { title: 'Gap', code: `gap-${tailwindSize}` },
-      { title: 'Border Width', code: `border-${tailwindSize}` },
       {
-        title: 'Position',
+        title: "Font Size",
+        code: remToTailwindFontSizeMap[em]
+          ? remToTailwindFontSizeMap[em]
+          : `text-[${em.toFixed(3)}rem]`,
+      },
+      { title: "Height", code: `h-${tailwindSize}` },
+      { title: "Width", code: `w-${tailwindSize}` },
+      { title: "Margin", code: `m-${tailwindSize}` },
+      { title: "Padding", code: `p-${tailwindSize}` },
+      { title: "Gap", code: `gap-${tailwindSize}` },
+      { title: "Border Width", code: `border-${tailwindSize}` },
+      {
+        title: "Position",
         code: `top-${tailwindSize}\nright-${tailwindSize}\nbottom-${tailwindSize}\nleft-${tailwindSize}`,
       },
     ],
     NaN: [
-      { title: 'Font Size', code: 'font-size: --' },
-      { title: 'Height', code: 'height: --' },
-      { title: 'Width', code: 'width: --' },
-      { title: 'Margin', code: 'margin: --' },
-      { title: 'Padding', code: 'padding: --' },
-      { title: 'Gap', code: 'gap: --' },
-      { title: 'Border Width', code: 'border-width: --' },
+      { title: "Font Size", code: "font-size: --" },
+      { title: "Height", code: "height: --" },
+      { title: "Width", code: "width: --" },
+      { title: "Margin", code: "margin: --" },
+      { title: "Padding", code: "padding: --" },
+      { title: "Gap", code: "gap: --" },
+      { title: "Border Width", code: "border-width: --" },
       {
-        title: 'Position',
+        title: "Position",
         code: `top: --\nright: --\nbottom: --\nleft: --`,
       },
     ],
     NaNtailwind: [
-      { title: 'Font Size', code: `text-` },
-      { title: 'Height', code: `h-` },
-      { title: 'Width', code: `w-` },
-      { title: 'Margin', code: `m-` },
-      { title: 'Padding', code: `p-` },
-      { title: 'Gap', code: `gap-` },
-      { title: 'Border Width', code: `border-` },
+      { title: "Font Size", code: `text-` },
+      { title: "Height", code: `h-` },
+      { title: "Width", code: `w-` },
+      { title: "Margin", code: `m-` },
+      { title: "Padding", code: `p-` },
+      { title: "Gap", code: `gap-` },
+      { title: "Border Width", code: `border-` },
       {
-        title: 'Position',
+        title: "Position",
         code: `top-\nright-\nbottom-\nleft-`,
       },
     ],
   };
 
-  const tabButtons = ['Rem', 'Em', 'Px', 'Tailwind'];
+  const tabButtons = ["Rem", "Em", "Px", "Tailwind"];
 
   //TabSwitcher Content
 
   const tabContents = [
     <div key="tab-rem" className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
-        ? CodeSamples['NaN'].map((sample, index) => (
+        ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -99,7 +121,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
               toastState={toastState}
             />
           ))
-        : CodeSamples['rem'].map((sample, index) => (
+        : CodeSamples["rem"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -111,7 +133,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
 
     <div key="tab-em" className="grid grid-cols-4 gap-4">
       {isNaN(em)
-        ? CodeSamples['NaN'].map((sample, index) => (
+        ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -119,7 +141,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
               toastState={toastState}
             />
           ))
-        : CodeSamples['em'].map((sample, index) => (
+        : CodeSamples["em"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -131,7 +153,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
 
     <div key="tab-px" className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
-        ? CodeSamples['NaN'].map((sample, index) => (
+        ? CodeSamples["NaN"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -139,7 +161,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
               toastState={toastState}
             />
           ))
-        : CodeSamples['px'].map((sample, index) => (
+        : CodeSamples["px"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -151,7 +173,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
 
     <div key="tab-tailwind" className="grid grid-cols-4 gap-4">
       {isNaN(pixels)
-        ? CodeSamples['NaNtailwind'].map((sample, index) => (
+        ? CodeSamples["NaNtailwind"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}
@@ -160,7 +182,7 @@ export default function CodeSnippets({ pixels, em, tailwindSize, toastState }) {
               toastState={toastState}
             />
           ))
-        : CodeSamples['tailwind'].map((sample, index) => (
+        : CodeSamples["tailwind"].map((sample, index) => (
             <CodeBlock
               key={`${sample.title}-${index}`}
               title={sample.title}

--- a/fetools-app/src/components/UnitConverter/Preview.jsx
+++ b/fetools-app/src/components/UnitConverter/Preview.jsx
@@ -1,4 +1,4 @@
-import { ToolPreviewPane } from '../ToolsLayout/Sections';
+import { ToolPreviewPane } from "../ToolsLayout/Sections";
 
 export default function Preview({
   alertShown = false,
@@ -26,7 +26,7 @@ export default function Preview({
       )}
 
       <div
-        className="flex flex-row items-center justify-center w-full h-full p-3 overflow-auto"
+        className="flex flex-row items-center justify-center w-full h-full p-3"
         style={gridBackgroundStyle}
       >
         <div

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -261,6 +261,7 @@ function UnitConverter() {
           onTailwindBlur={onTailwindBlur}
           basePixelSize={basePixelSize}
           handleBasePixelSizeChange={handleBasePixelSizeChange}
+          toastState={toastState}
         />
         <Preview
           alertShown={alertShown}

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -1,21 +1,20 @@
-import '../index.css';
-import GoDeeper from '../components/ToolsLayout/GoDeeper';
-import ToolHeading from '../components/ToolsLayout/ToolHeading';
+import "../index.css";
+import GoDeeper from "../components/ToolsLayout/GoDeeper";
+import ToolHeading from "../components/ToolsLayout/ToolHeading";
 
-import { useState, useEffect, useRef } from 'react';
-import ToolMain from '../components/ToolsLayout/ToolMain';
+import { useState, useEffect, useRef } from "react";
+import ToolMain from "../components/ToolsLayout/ToolMain";
 import {
   ToolSection,
   ToolSectionColumns,
-} from '../components/ToolsLayout/Sections';
-import Calculator from '../components/UnitConverter/Calculator';
-import Preview from '../components/UnitConverter/Preview';
-import CodeSnippets from '../components/UnitConverter/CodeSnippets';
-import Toast from '../components/Toast';
+} from "../components/ToolsLayout/Sections";
+import Calculator from "../components/UnitConverter/Calculator";
+import Preview from "../components/UnitConverter/Preview";
+import CodeSnippets from "../components/UnitConverter/CodeSnippets";
+import Toast from "../components/Toast";
 
-import useExpander from '../hooks/useExpander';
-import useToastState from '../hooks/useToastState';
-
+import useExpander from "../hooks/useExpander";
+import useToastState from "../hooks/useToastState";
 
 // Function component UnitConverter for converting units between pixels, em/rem, and Tailwind utility classes
 
@@ -28,18 +27,24 @@ function UnitConverter() {
   const [cssSize, setCssSize] = useState(`${pixels}px`);
 
   // State to hold the content of the contentEditable div
-  const [editableContent, setEditableContent] = useState('Aa');
+  const [editableContent, setEditableContent] = useState("Aa");
 
   // Function to handle changes in the contentEditable div
   const editableRef = useRef(null);
 
   // Hook to manage expanding preview
   const [isExpanded, toggleIsExpanded] = useExpander();
-  const toastState = useToastState()
- 
+  const toastState = useToastState();
+
   const handleContentChange = () => {
     const newText = editableRef.current.innerText;
-    if (newText !== editableContent) {
+
+    // Check if the contentEditable div is empty after the change
+    if (newText.trim() === "") {
+      // Insert a non-breaking space as placeholder to maintain the div's height
+      editableRef.current.innerHTML = "&nbsp;";
+    } else if (newText !== editableContent) {
+      // Update the state only if the new text is different and not empty
       setEditableContent(newText);
     }
   };
@@ -56,7 +61,7 @@ function UnitConverter() {
   const [alertShown, setAlertShown] = useState(false);
 
   // Update CSS size whenever pixels, em, or Tailwind size changes
-  const updateCssSize = newSizeInPixels => {
+  const updateCssSize = (newSizeInPixels) => {
     let finalSize = newSizeInPixels;
     let displayNote = false;
 
@@ -67,7 +72,7 @@ function UnitConverter() {
     }
 
     // Check if newSizeInPixels is a number, if not, set CSS size to "0px"
-    setCssSize(isNaN(finalSize) ? '0px' : `${finalSize}px`); // Update CSS size
+    setCssSize(isNaN(finalSize) ? "0px" : `${finalSize}px`); // Update CSS size
 
     // Update the state to control the visibility of the inline notification
     setAlertShown(displayNote);
@@ -99,12 +104,12 @@ function UnitConverter() {
     24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64, 72, 80, 96,
   ];
 
-  const tailwindCheck = TailwindSize => {
-    if (isNaN(TailwindSize) || TailwindSize === '') {
-      return '';
+  const tailwindCheck = (TailwindSize) => {
+    if (isNaN(TailwindSize) || TailwindSize === "") {
+      return "";
     }
     const nearestTailwindSize = tailwindSizes.find(
-      size => size == TailwindSize
+      (size) => size == TailwindSize
     );
     if (nearestTailwindSize !== undefined) {
       return nearestTailwindSize;
@@ -114,7 +119,7 @@ function UnitConverter() {
   };
 
   // Handler for base pixel size changes
-  const handleBasePixelSizeChange = e => {
+  const handleBasePixelSizeChange = (e) => {
     const newBaseSize = parseFloat(e.target.value);
     setBasePixelSize(newBaseSize);
     const newEm = pixels / newBaseSize;
@@ -123,7 +128,7 @@ function UnitConverter() {
   };
 
   // Handler for pixel value changes
-  const handlePixelChange = e => {
+  const handlePixelChange = (e) => {
     const newPixels = parseFloat(e.target.value);
     setPixels(newPixels);
     const newEm = newPixels / basePixelSize;
@@ -133,7 +138,7 @@ function UnitConverter() {
   };
 
   // Handler for rem/em value changes
-  const handleEmChange = e => {
+  const handleEmChange = (e) => {
     const newEm = parseFloat(e.target.value);
     setEm(newEm);
     const newPixels = newEm * basePixelSize;
@@ -143,27 +148,27 @@ function UnitConverter() {
   };
 
   // Tailwind Size Character Validation
-  const isValidCharacter = char => {
-    const validChars = '[],pxrem.';
+  const isValidCharacter = (char) => {
+    const validChars = "[],pxrem.";
     return validChars.includes(char) || !isNaN(char);
   };
 
   // Tailwind Size Format Check
-  const formatCheck = input => {
+  const formatCheck = (input) => {
     // Check if input is in the allowed format [Xrem] or [Xpx], if so, return as is
     if (
-      (input.startsWith('[') && input.endsWith('rem]')) ||
-      (input.startsWith('[') && input.endsWith('px]'))
+      (input.startsWith("[") && input.endsWith("rem]")) ||
+      (input.startsWith("[") && input.endsWith("px]"))
     ) {
       return input;
     }
 
     // Remove all non-numeric characters except for the decimal point
-    return input.replace(/[^\d.]/g, '');
+    return input.replace(/[^\d.]/g, "");
   };
 
   // Handler for Tailwind Size changes
-  const handleTailwindChange = e => {
+  const handleTailwindChange = (e) => {
     const inputValue = e.target.value.toString();
     const lastChar = inputValue.slice(-1); // Get the last character
 
@@ -180,7 +185,7 @@ function UnitConverter() {
     let newEm;
 
     // Checks if the input value is in the format [X.XXXrem] and parses it correctly
-    if (formattedValue.startsWith('[') && formattedValue.endsWith('rem]')) {
+    if (formattedValue.startsWith("[") && formattedValue.endsWith("rem]")) {
       // Extracts the numeric part and parses it as float
       const remValue = formattedValue.slice(1, -4);
       if (!isNaN(remValue)) {
@@ -191,8 +196,8 @@ function UnitConverter() {
         newEm = 0;
       }
     } else if (
-      formattedValue.startsWith('[') &&
-      formattedValue.endsWith('px]')
+      formattedValue.startsWith("[") &&
+      formattedValue.endsWith("px]")
     ) {
       // Extracts the numeric part and parses it as float
       const pxValue = formattedValue.slice(1, -3);
@@ -220,11 +225,11 @@ function UnitConverter() {
   const onTailwindBlur = () => {
     let newTailwindSize;
 
-    if (tailwindSize.startsWith('[') && tailwindSize.endsWith('rem]')) {
+    if (tailwindSize.startsWith("[") && tailwindSize.endsWith("rem]")) {
       const remValue = tailwindSize.slice(1, -4);
       let newEm = remValue;
       newTailwindSize = newEm * 4;
-    } else if (tailwindSize.startsWith('[') && tailwindSize.endsWith('px]')) {
+    } else if (tailwindSize.startsWith("[") && tailwindSize.endsWith("px]")) {
       const pxValue = tailwindSize.slice(1, -3);
       let newPx = pxValue;
       let newEm = newPx / basePixelSize;
@@ -270,27 +275,32 @@ function UnitConverter() {
 
       {/* Section for code blocks */}
       <ToolSection icon="integration_instructions" title="Code Snippets">
-        <CodeSnippets pixels={pixels} em={em} tailwindSize={tailwindSize} toastState={toastState}/>
+        <CodeSnippets
+          pixels={pixels}
+          em={em}
+          tailwindSize={tailwindSize}
+          toastState={toastState}
+        />
       </ToolSection>
 
       <GoDeeper
         linksData={[
           {
-            url: 'https://www.w3schools.com/cssref/css_units.php',
-            textValue: 'Explore CSS units at W3Schools',
+            url: "https://www.w3schools.com/cssref/css_units.php",
+            textValue: "Explore CSS units at W3Schools",
           },
           {
-            url: 'https://developer.mozilla.org/en-US/docs/Web/CSS',
-            textValue: 'Learn more about CSS values and units at MDN',
+            url: "https://developer.mozilla.org/en-US/docs/Web/CSS",
+            textValue: "Learn more about CSS values and units at MDN",
           },
           {
-            url: 'https://www.youtube.com/watch?v=N5wpD9Ov_To&ab_channel=KevinPowell',
-            textValue: 'Are you using the right CSS units? With Kevin Powell',
+            url: "https://www.youtube.com/watch?v=N5wpD9Ov_To&ab_channel=KevinPowell",
+            textValue: "Are you using the right CSS units? With Kevin Powell",
           },
         ]}
       />
 
-      <Toast toastState={toastState}/>
+      <Toast toastState={toastState} />
     </ToolMain>
   );
 }

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -237,7 +237,7 @@ function UnitConverter() {
     } else {
       newTailwindSize = tailwindSize;
     }
-    setTailwindSize(tailwindCheck(formatCheck(newTailwindSize)));
+    setTailwindSize(tailwindCheck(newTailwindSize));
   };
 
   // JSX for rendering the UI components.

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -231,7 +231,7 @@ function UnitConverter() {
       const remValue = tailwindSize.slice(1, -4);
       let newEm = remValue;
       newTailwindSize = newEm * 4;
-      finalTailwindSize = tailwindCheck(newTailwindSize);
+      finalTailwindSize = tailwindCheck(formatCheck(newTailwindSize));
       setTailwindSize(finalTailwindSize);
 
       if (finalTailwindSize != tailwindSize) {
@@ -248,7 +248,7 @@ function UnitConverter() {
       let newPx = pxValue;
       let newEm = newPx / basePixelSize;
       newTailwindSize = newEm * 4;
-      finalTailwindSize = tailwindCheck(newTailwindSize);
+      finalTailwindSize = tailwindCheck(formatCheck(newTailwindSize));
       setTailwindSize(finalTailwindSize);
 
       if (finalTailwindSize != tailwindSize) {
@@ -262,7 +262,7 @@ function UnitConverter() {
       }
     } else {
       newTailwindSize = tailwindSize;
-      finalTailwindSize = tailwindCheck(newTailwindSize);
+      finalTailwindSize = tailwindCheck(formatCheck(newTailwindSize));
       setTailwindSize(finalTailwindSize);
 
       if (finalTailwindSize != tailwindSize) {

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -35,6 +35,7 @@ function UnitConverter() {
   // Hook to manage expanding preview
   const [isExpanded, toggleIsExpanded] = useExpander();
   const toastState = useToastState();
+  const { setOpenToast, setToastContent } = toastState;
 
   const handleContentChange = () => {
     const newText = editableRef.current.innerText;
@@ -224,20 +225,56 @@ function UnitConverter() {
   //Tailwind Blur Function - handles entered tailwind sizes that don't exist
   const onTailwindBlur = () => {
     let newTailwindSize;
+    let finalTailwindSize;
 
     if (tailwindSize.startsWith("[") && tailwindSize.endsWith("rem]")) {
       const remValue = tailwindSize.slice(1, -4);
       let newEm = remValue;
       newTailwindSize = newEm * 4;
+      finalTailwindSize = tailwindCheck(newTailwindSize);
+      setTailwindSize(finalTailwindSize);
+
+      if (finalTailwindSize != tailwindSize) {
+        // Set the toast content and open the toast
+        setToastContent({
+          title: "Invalid Arbitrary REM Value",
+          content: `Entered value, ${tailwindSize}, has a corresponding Tailwind Size value of ${finalTailwindSize} and has been updated accordingly.`,
+          icon: "info",
+        });
+        setOpenToast(true);
+      }
     } else if (tailwindSize.startsWith("[") && tailwindSize.endsWith("px]")) {
       const pxValue = tailwindSize.slice(1, -3);
       let newPx = pxValue;
       let newEm = newPx / basePixelSize;
       newTailwindSize = newEm * 4;
+      finalTailwindSize = tailwindCheck(newTailwindSize);
+      setTailwindSize(finalTailwindSize);
+
+      if (finalTailwindSize != tailwindSize) {
+        // Set the toast content and open the toast
+        setToastContent({
+          title: "Invalid Arbitrary PX Value",
+          content: `Entered value, ${tailwindSize}, has a corresponding Tailwind Size value of ${finalTailwindSize} and has been updated accordingly.`,
+          icon: "eyedrop",
+        });
+        setOpenToast(true);
+      }
     } else {
       newTailwindSize = tailwindSize;
+      finalTailwindSize = tailwindCheck(newTailwindSize);
+      setTailwindSize(finalTailwindSize);
+
+      if (finalTailwindSize != tailwindSize) {
+        // Set the toast content and open the toast
+        setToastContent({
+          title: "Invalid Tailwind Size",
+          content: `Entered value, ${tailwindSize}, is not an existing Tailwind Size. It has been updated to an arbitrary REM value, ${finalTailwindSize}.`,
+          icon: "copy",
+        });
+        setOpenToast(true);
+      }
     }
-    setTailwindSize(tailwindCheck(newTailwindSize));
   };
 
   // JSX for rendering the UI components.

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -224,14 +224,18 @@ function UnitConverter() {
 
   //Tailwind Blur Function - handles entered tailwind sizes that don't exist
   const onTailwindBlur = () => {
+    let formattedTailwindSize = formatCheck(tailwindSize);
     let newTailwindSize;
     let finalTailwindSize;
 
-    if (tailwindSize.startsWith("[") && tailwindSize.endsWith("rem]")) {
+    if (
+      formattedTailwindSize.startsWith("[") &&
+      formattedTailwindSize.endsWith("rem]")
+    ) {
       const remValue = tailwindSize.slice(1, -4);
       let newEm = remValue;
       newTailwindSize = newEm * 4;
-      finalTailwindSize = tailwindCheck(formatCheck(newTailwindSize));
+      finalTailwindSize = tailwindCheck(newTailwindSize);
       setTailwindSize(finalTailwindSize);
 
       if (finalTailwindSize != tailwindSize) {
@@ -243,12 +247,15 @@ function UnitConverter() {
         });
         setOpenToast(true);
       }
-    } else if (tailwindSize.startsWith("[") && tailwindSize.endsWith("px]")) {
+    } else if (
+      formattedTailwindSize.startsWith("[") &&
+      formattedTailwindSize.endsWith("px]")
+    ) {
       const pxValue = tailwindSize.slice(1, -3);
       let newPx = pxValue;
       let newEm = newPx / basePixelSize;
       newTailwindSize = newEm * 4;
-      finalTailwindSize = tailwindCheck(formatCheck(newTailwindSize));
+      finalTailwindSize = tailwindCheck(newTailwindSize);
       setTailwindSize(finalTailwindSize);
 
       if (finalTailwindSize != tailwindSize) {
@@ -261,15 +268,15 @@ function UnitConverter() {
         setOpenToast(true);
       }
     } else {
-      newTailwindSize = tailwindSize;
-      finalTailwindSize = tailwindCheck(formatCheck(newTailwindSize));
+      newTailwindSize = formattedTailwindSize;
+      finalTailwindSize = tailwindCheck(newTailwindSize);
       setTailwindSize(finalTailwindSize);
 
-      if (finalTailwindSize != tailwindSize) {
+      if (finalTailwindSize != formattedTailwindSize) {
         // Set the toast content and open the toast
         setToastContent({
           title: "Invalid Tailwind Size",
-          content: `Entered value, ${tailwindSize}, is not an existing Tailwind Size. It has been updated to an arbitrary REM value, ${finalTailwindSize}.`,
+          content: `Entered value, ${newTailwindSize}, is not an existing Tailwind Size. It has been updated to an arbitrary REM value, ${finalTailwindSize}.`,
           icon: "error",
         });
         setOpenToast(true);

--- a/fetools-app/src/pages/UnitConverter.jsx
+++ b/fetools-app/src/pages/UnitConverter.jsx
@@ -239,7 +239,7 @@ function UnitConverter() {
         setToastContent({
           title: "Invalid Arbitrary REM Value",
           content: `Entered value, ${tailwindSize}, has a corresponding Tailwind Size value of ${finalTailwindSize} and has been updated accordingly.`,
-          icon: "info",
+          icon: "error",
         });
         setOpenToast(true);
       }
@@ -256,7 +256,7 @@ function UnitConverter() {
         setToastContent({
           title: "Invalid Arbitrary PX Value",
           content: `Entered value, ${tailwindSize}, has a corresponding Tailwind Size value of ${finalTailwindSize} and has been updated accordingly.`,
-          icon: "eyedrop",
+          icon: "error",
         });
         setOpenToast(true);
       }
@@ -270,7 +270,7 @@ function UnitConverter() {
         setToastContent({
           title: "Invalid Tailwind Size",
           content: `Entered value, ${tailwindSize}, is not an existing Tailwind Size. It has been updated to an arbitrary REM value, ${finalTailwindSize}.`,
-          icon: "copy",
+          icon: "error",
         });
         setOpenToast(true);
       }


### PR DESCRIPTION
This PR should cover the majority of the changes that were required for the Unit Converter (I think). In hindsight, I probably should have made a PR earlier as I ended up changing a lot of files, my bad! 

### Below are the important changes made:

**UnitConverter.jsx:**
- Altered onTailWindBlur function to add toasts for when tailwind size is changed to arbitrary REM values and when arbitrary REM/PX values are changed to tailwind sizes (if they exist)

**Calculator.jsx:**
- Added toastState so there is toasts for the copy button in the calculator
- Added arrow icons between textfields
- Optimized for different screen sizes, textfields placement become flex column rather than row for small screens

**TextField.jsx:**
- Optimized width and placement for different screen sizes, text centered

**CodeBlock.jsx:**
- Redundant import react line removed
- renderCodeWithHighlight function has been altered so lines are only split into property and value when necessary, in case the code also contains opening/closing block lines (such as in Oleg's font viewer CSS code)
- Background color changed to a lighter grey
- Light grey border added to code block

**CodeSnippets.jsx:**
- Updated tailwind font size snippets to be valid entries (such as text-xs rather than text-{tailwindSize}) 
- Code snippets grid optimized for different size screens, four columns for large screens, two columns for medium screens, one column for small screens

**EditableInput.jsx:**
- Padding added so input doesn't overlap with unit text, and input field text centered

**TabSwitcher.jsx:**
- Gap between buttons changed for smaller screens so they all fit on one line

### Questions:

- Is it fine if the grid lines stay solid? Couldn't find a way to make them dashed.
- Do I have to add the bookmark component anywhere to the unit converter?

Let me know if you catch anything else that needs to be changed!