### PR TITLE
112 forward home to color picker and reorder nav

### DIFF
--- a/fetools-app/src/App.jsx
+++ b/fetools-app/src/App.jsx
@@ -1,9 +1,8 @@
-import { Outlet } from 'react-router-dom';
-import Header from './components/PageLayout/Header';
-import Footer from './components/PageLayout/Footer';
+import { Outlet } from "react-router-dom";
+import Header from "./components/PageLayout/Header";
+import Footer from "./components/PageLayout/Footer";
 
-import './index.css';
-import Toast from './components/Toast';
+import "./index.css";
 
 function App() {
   return (

--- a/fetools-app/src/components/PageLayout/Nav.jsx
+++ b/fetools-app/src/components/PageLayout/Nav.jsx
@@ -1,23 +1,23 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import Icon from '../Icon';
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import Icon from "../Icon";
 
 const Links = [
-  { to: '/characters', icon: 'Ampersand', iconType: 'svg', text: 'Characters' },
-  { to: '/colors', icon: 'colorize', text: 'Colors' },
-  { to: '/fonts', icon: 'format_size', text: 'Fonts' },
-  { to: '/gradients', icon: 'gradient', text: 'Gradients' },
-  { to: '/shadows', icon: 'ev_shadow', text: 'Shadows' },
-  { to: '/tables', icon: 'table', text: 'Tables' },
-  { to: '/units', icon: 'sync', text: 'Units', className: 'rotate-90' },
+  { to: "/colors", icon: "colorize", text: "Colors" },
+  { to: "/gradients", icon: "gradient", text: "Gradients" },
+  { to: "/shadows", icon: "ev_shadow", text: "Shadows" },
+  { to: "/characters", icon: "Ampersand", iconType: "svg", text: "Characters" },
+  { to: "/tables", icon: "table", text: "Tables" },
+  { to: "/units", icon: "sync", text: "Units", className: "rotate-90" },
+  { to: "/fonts", icon: "format_size", text: "Fonts" },
 ].map(({ to, icon, iconType, text, className }) => (
   <li key={to} className="border-gray-200 max-md:w-full max-md:border">
     <Link to={to} className="max-md:p-4">
       <Icon
         name={icon}
-        type={iconType ? iconType : 'material'}
+        type={iconType ? iconType : "material"}
         className={className && className}
-      />{' '}
+      />{" "}
       {text}
     </Link>
   </li>
@@ -27,16 +27,16 @@ export default function Nav() {
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    const clickListener = e =>
-      e.target.closest('.hamburger') === null && setIsExpanded(false);
+    const clickListener = (e) =>
+      e.target.closest(".hamburger") === null && setIsExpanded(false);
 
-    const escListener = e => e.key === 'Escape' && setIsExpanded(false);
+    const escListener = (e) => e.key === "Escape" && setIsExpanded(false);
 
-    document.addEventListener('click', clickListener);
-    document.addEventListener('keydown', escListener);
+    document.addEventListener("click", clickListener);
+    document.addEventListener("keydown", escListener);
     return () => {
-      document.removeEventListener('click', clickListener);
-      document.removeEventListener('keydown', escListener);
+      document.removeEventListener("click", clickListener);
+      document.removeEventListener("keydown", escListener);
     };
   }, []);
 
@@ -44,7 +44,7 @@ export default function Nav() {
     <div>
       <nav
         className={`flex w-full justify-center gap-0 bg-white max-md:absolute max-md:right-0 max-md:top-20 max-md:z-50 md:pb-4 xl:pb-0 xl:justify-end ${
-          isExpanded ? '' : 'max-md:hidden'
+          isExpanded ? "" : "max-md:hidden"
         }`}
       >
         <ul className="max-md:border-1 max-md:w-screen flex h-full flex-wrap items-center justify-center gap-x-4 font-bold max-md:flex-col max-md:border-gray-200 max-md:text-center max-md:shadow-md sm:w-full sm:justify-center lg:gap-8 xl:justify-end [&>li>a]:flex [&>li>a]:gap-2 [&_.icon]:text-accent">
@@ -55,7 +55,7 @@ export default function Nav() {
         name={isExpanded ? `close` : `menu`}
         size="40"
         className="hamburger cursor-pointer select-none md:hidden"
-        onClick={() => setIsExpanded(prev => !prev)}
+        onClick={() => setIsExpanded((prev) => !prev)}
       />
     </div>
   );

--- a/fetools-app/src/pages/Home.jsx
+++ b/fetools-app/src/pages/Home.jsx
@@ -1,66 +1,10 @@
-import ToolHeaderSection from '../components/ToolsLayout/ToolHeaderSection';
-import GoDeeper from '../components/ToolsLayout/GoDeeper';
-import ToolHeading from '../components/ToolsLayout/ToolHeading';
-import TabSwitcher from '../components/TabSwitcher';
-import PageSection from '../components/PageLayout/PageSection';
-
-function TestContent1() {
-  return <p>Test Content 1</p>;
-}
-
-function TestContent2() {
-  return <p>Test Content 2</p>;
-}
-
-function TestContent3() {
-  return <p>Test Content 3</p>;
-}
+import { useEffect } from "react";
 
 function Home() {
-  const linksData = [
-    {
-      url: 'https://en.wikipedia.org/wiki/Gabe_Newell',
-      textValue: 'Dummy Link 1',
-    },
-    {
-      url: 'https://en.wikipedia.org/wiki/SteamOS',
-      textValue: 'Dummy Link 2',
-    },
-    {
-      url: 'https://en.wikipedia.org/wiki/Half-Life:_Alyx',
-      textValue: 'Dummy Link 3',
-    },
-  ];
-
-  return (
-    <main className="flex-col mt-8 sm:mt-12 lg:mt-20">
-      <PageSection title="Options" icon="tune">
-        <p>Here is the content.</p>
-      </PageSection>
-
-      <ToolHeaderSection>
-        <ToolHeading
-          title="Tool title"
-          tagline="
-        Tool tag line Tool tagline Tool tagline Tool tagline Tool tagline Tool tagline Tool tagline"
-        />
-        <ToolHeading
-          title="Tool title"
-          tagline="
-        Tool tag line Tool tagline Tool tagline Tool tagline Tool tagline Tool tagline Tool tagline"
-        />
-      </ToolHeaderSection>
-
-      <TabSwitcher buttons={['rem', 'em', 'px']}>
-        <TestContent1 />
-        <TestContent2 />
-        <TestContent3 />
-      </TabSwitcher>
-
-      <GoDeeper linksData={linksData} />
-
-    </main>
-  );
+  useEffect(() => {
+    window.location.href = "/colors";
+  }, []);
+  return null;
 }
 
 export default Home;

--- a/fetools-app/src/pages/Home.jsx
+++ b/fetools-app/src/pages/Home.jsx
@@ -4,7 +4,7 @@ function Home() {
   useEffect(() => {
     window.location.href = "/colors";
   }, []);
-  return null;
+  return <main className="h-[100vh]"></main>;
 }
 
 export default Home;


### PR DESCRIPTION
Reordered tools as follows to move across a natural spectrum from color and design tools to textual tools.

- Colors
- Gradients
- Shadows
- Tables
- Units
- Fonts
- Characters

Also redirected home page to color picker. Resolves issues #112 and #113 