### PR TITLE
Modify GoDeeper.jsx to use "live_tv" icon for YouTube links.

### DIFF
--- a/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
+++ b/fetools-app/src/components/ToolsLayout/GoDeeper.jsx
@@ -2,12 +2,20 @@ import { ToolSection } from "./Sections";
 import Icon from "../Icon";
 
 export default function GoDeeper({ linksData }) {
+  // Add icons to links
+  linksData = linksData.map((link) => {
+    return {
+      icon: link.url.includes("youtube") ? "live_tv" : "Link",
+      iconType: link.url.includes("youtube") ? "material" : "svg",
+      ...link,
+    };
+  });
   const anchorElements = (array) =>
-    array.map(({ url, textValue }, idx) => (
+    array.map(({ url, textValue, icon, iconType }, idx) => (
       <li key={`GoLink-${idx}`}>
         <div className="flex items-start gap-2">
           <div className="pt-1">
-            <Icon name="Link" type="svg" size="18" />
+            <Icon name={icon} type={iconType} size="18" />
           </div>
           <a
             href={url}


### PR DESCRIPTION
Resolves issue #141 

When the Go Deeper link url points to a Youtube video, the link icon is now MDI "live_tv"

<img width="285" alt="Screenshot 2024-02-21 at 8 48 05 PM" src="https://github.com/chingu-voyages/v47-tier2-team-17/assets/8323435/147cad8f-df4c-4ef4-ab4a-73f651035d83">
